### PR TITLE
fix: stop autoloading session, call is explicitly instead

### DIFF
--- a/SQLFunctions.php
+++ b/SQLFunctions.php
@@ -1,6 +1,6 @@
 <?php
     require_once 'vendor/autoload.php';
-    include('config.php');
+
     $rejectredirecturl = 'Fail.html';
     $successredirecturl = 'dashboard.php';
     $duplicate = 'duplicate.php'; // this file doesn't exist

--- a/api/def/csv.php
+++ b/api/def/csv.php
@@ -1,5 +1,6 @@
 <?php
 require 'vendor/autoload.php';
+session_start();
 
 // Thanks go to this gist in writing this code:
 // https://gist.github.com/johanmeiring/2894568

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
         "nesbot/carbon": "^2.4"
     },
     "autoload": {
-        "files": [ "session.php", "config.php" ]
+        "files": [ "config.php" ]
     }
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -105,9 +105,9 @@ if (!empty($_SESSION['userID'])) {
   // instantiate Twig
   $loader = new Twig_Loader_Filesystem('templates');
   $twig = new Twig_Environment($loader, [
-      'debug' => PHP_ENV === 'dev' ? true : false
+      'debug' => getenv('PHP_ENV') === 'dev'
   ]);
-  if (PHP_ENV === 'dev') $twig->addExtension(new Twig_Extension_Debug());
+  if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug());
 
   // instantiate report object
   $weeklySIT3delta = new WeeklyDelta('SIT3');

--- a/defs.php
+++ b/defs.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'vendor/autoload.php';
+require_once 'session.php';
 
 // check which view to show
 $view = !empty(($_GET['view']))


### PR DESCRIPTION
Autoloading session causes infinite redirect loop from login page

Remove session from autoload. Call it where needed.