### PR TITLE
fix: re-encode stray '\r\n' and don't insert empty string in date fields

### DIFF
--- a/defs.php
+++ b/defs.php
@@ -4,7 +4,7 @@ require_once 'session.php';
 
 // check which view to show
 $view = !empty(($_GET['view']))
-    ? filter_var($_GET['view'], FILTER_SANITIZE_SPECIAL_CHARS) : '';
+    ? filter_var($_GET['view'], FILTER_SANITIZE_ENCODED) : '';
 $orderBy = null;
 
 // check for search params

--- a/model/BARTDeficiency.php
+++ b/model/BARTDeficiency.php
@@ -62,6 +62,44 @@ class BARTDeficiency extends Deficiency {
         'newComment' => null
     ];
 
+    protected $filters = [
+        'id' => 'intval',
+        'created_by' => 'intval',
+        'dateCreated' => 'date',
+        'updated_by' => 'intval',
+        'lastUpdated' => 'date',
+        'creator' => 'intval',
+        'next_step' => 'intval',
+        'bic' => 'intval',
+        'status' => 'intval',
+        'descriptive_title_vta' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'root_prob_vta' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'resolution_vta' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'priority_vta' => 'intval',
+        'agree_vta' => 'intval',
+        'safety_cert_vta' => 'intval',
+        'resolution_disputed' => 'intval',
+        'structural' => 'intval',
+        'id_bart' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'description_bart' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'cat1_bart' => null,
+        'cat2_bart' => null,
+        'cat3_bart' => null,
+        'level_bart' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'dateOpen_bart' => 'date',
+        'dateClose_bart' => 'date',
+        'dateClosed' => 'date',
+        'repo' => 'intval',
+        'evidenceID' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'evidenceType' => 'intval',
+        'evidenceLink' => 'FILTER_SANITIZE_ENCODED',
+        'closureComment' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'attachments' => null,
+        'newAttachment' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'comments' => null,
+        'newComment' => 'FILTER_SANITIZE_SPECIAL_CHARS'
+    ];
+
     protected $fields = [
         'id' => 'id',
         'created_by' => 'created_by',

--- a/model/BARTDeficiency.php
+++ b/model/BARTDeficiency.php
@@ -4,7 +4,7 @@ namespace SVBX;
 use MysqliDb;
 
 class BARTDeficiency extends Deficiency {
-    protected $timestampField = 'form_modified';
+    const TIMESTAMP_FIELD = 'form_modified';
 
     protected $table = 'BARTDL';
     public $commentsTable = [

--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -305,9 +305,9 @@ class Deficiency
                 $acc[$key] = $this->filters[$key]($props[$key]) ?: null;
             }
             else $acc[$key] = $props[$key];
-            // stripcslashes here should be temporary
+            // trim & stripcslashes here should be temporary
             // may be removed once all tainted Defs are cleaned of '\r\n'
-            $acc[$key] = stripcslashes($acc[$key]);
+            $acc[$key] = trim(stripcslashes($acc[$key]));
             return $acc;
         }, []);
     }

--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -64,6 +64,41 @@ class Deficiency
         'newPic' => null
     ];
 
+    protected $filters = [
+        'id' => 'intval',
+        'safetyCert' => 'intval',
+        'systemAffected' => 'intval',
+        'location' => 'intval',
+        'specLoc' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'status' => 'intval',
+        'severity' => 'intval',
+        'dueDate' => 'date',
+        'groupToResolve' => 'intval',
+        'requiredBy' => 'intval',
+        'contractID' => 'intval',
+        'identifiedBy' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'defType' => 'intval',
+        'description' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'spec' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'actionOwner' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'evidenceType' => 'intval',
+        'repo' => 'intval',
+        'evidenceID' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'evidenceLink' => 'FILTER_SANITIZE_ENCODED',
+        'oldID' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'closureComments' => 'FILTER_SANITIZE_SPECIAL_CHARS',
+        'created_by' => null,
+        'updated_by' => null,
+        'dateCreated' => 'date',
+        'dateClosed' => 'date',
+        'closureRequested' => 'intval',
+        'closureRequestedBy' => null,
+        'comments' => null,
+        'newComment' => null,
+        'pics' => null,
+        'newPic' => null
+    ];
+
     protected $fields = [
         'id' =>  'defID',
         'safetyCert' => 'safetyCert',
@@ -259,6 +294,18 @@ class Deficiency
         }, []);
     }
 
+    public function sanitize($props = null) {
+        $props = $props ?: $this->props;
+        return array_reduce(array_keys($props), function($acc, $key) use ($props) {
+            if (strpos($this->filters[$key], 'FILTER') === 0)
+                $acc[$key] = filter_var($props[$key], constant($this->filters[$key]));
+            elseif (!empty($this->filters[$key]))
+                $acc[$key] = $this->filters[$key]($props[$key]);
+            else $acc[$key] = $props[$key];
+            return $acc;
+        }, []);
+    }
+
     // TODO: validate types of props (string, int, date)
     public function validateCreationInfo($action, $props = null) { // TODO: takes an optional (String) single prop or (Array) of props to validate
         if ($action === 'insert') {
@@ -317,6 +364,7 @@ class Deficiency
         $insertableData = $this->propsToFields();
         unset($insertableData[$this->fields['id']]);
         unset($insertableData[$this->fields['lastUpdated']]);
+        $insertableData = $this->sanitize($insertableData);
         
         try {
             $link = new MysqliDb(DB_CREDENTIALS);
@@ -340,6 +388,7 @@ class Deficiency
 
         $updatableData = $this->propsToFields();
         unset($updatableData['id']);
+        $updatableData = $this->sanitize($updatableData);
 
         try {
             $link = new MysqliDb(DB_CREDENTIALS);


### PR DESCRIPTION
Rectifies some carelessness with sanitizing the data in the Def model.
- In the model, non-integer fields were getting FILTER_SANITIZE_SPECIAL_CHARS, which was evaluating _null_ to "" empty string. If the field was a date field, MySQL interpreted the empty string as the date '0000-00-00'. This PR maps each field in the model to a specific filter function so that null dates stay null. Also adds some temporary code to re-evaluate dates of '0000-00-00' to null before updating the Def record in the db.
- Before the model class existed, Defs were getting slash-escaped for db insertion, turning line breaks into literal '\r\n' characters. This PR adds some temporary code to re-encode these characters as line breaks and trim them if they're leading or trailing.

Temporary code in the PR can be removed once all tainted Defs have had their '\r\n' and '0000-00-00' encoded to the correct corresponding values.