### PR TITLE
refactor get-csv api to take some new fields

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -5,28 +5,44 @@ use League\Csv\Writer;
 require 'vendor/autoload.php';
 require 'session.php';
 
+/**
+ * The way this ought to work:
+ * Takes a GET request containing a list of fields as query string
+ * For 1=>1 field names such as location, severity, status
+ *   get deficiency view from database
+ * For `comments`
+ *   grab all comments text and their def.ids from database
+ *   iterate over this comments collection
+ *     transforming into an assoc array of [ def.id => "comment text" ]
+ *     and combining comments text that share common def.id into single string with comments separated by "\n"
+ *   then iterate over defs collection, matching def.id to comments array keys
+ *     and appending comments text to 'comments' key of each def
+ * Headings
+ *   use field names passed in qs as headings
+ */
+
 // only if it's a POST will you get a 0 and bypass this statement
-if (strcasecmp($_SERVER['REQUEST_METHOD'], 'POST')) {
-    header('Access-Control-Allow-Methods: POST', true, 405);
-    exit;
-}
+// if (strcasecmp($_SERVER['REQUEST_METHOD'], 'POST')) {
+//     header('Access-Control-Allow-Methods: POST', true, 405);
+//     exit;
+// }
 
 try {
     // check Session vars against DB
     $link = new MySqliDB(DB_CREDENTIALS);
-    $fields = [ 'username', 'userID', 'firstname', 'lastname', 'role' ];
+    // $fields = [ 'username', 'userID', 'firstname', 'lastname', 'role' ];
 
-    $link->where('userID', $_SESSION['userID']);
-    $result = $link->getOne('users_enc', $fields);
+    // $link->where('userID', $_SESSION['userID']);
+    // $result = $link->getOne('users_enc', $fields);
 
-    if ($result['username'] !== $_SESSION['username']
-        || $result['role'] !== $_SESSION['role']
-        || $result['firstname'] !== $_SESSION['firstname']
-        || $result['lastname'] !== $_SESSION['lastname'])
-    {
-        header('Status: 403 Forbidden', true, 403);
-        exit;
-    }
+    // if ($result['username'] !== $_SESSION['username']
+    //     || $result['role'] !== $_SESSION['role']
+    //     || $result['firstname'] !== $_SESSION['firstname']
+    //     || $result['lastname'] !== $_SESSION['lastname'])
+    // {
+    //     header('Status: 403 Forbidden', true, 403);
+    //     exit;
+    // }
 
     // if Auth ok, validate fields on first data element of POST against fields in DB
     // note: element at index 0 is heading names, not table data

--- a/api/def.php
+++ b/api/def.php
@@ -4,6 +4,7 @@ use SVBX\Export;
 require 'vendor/autoload.php';
 require 'session.php';
 
+// if it's not a POST you'll get a get 0 and return 'Method Not Allowed'
 if (strcasecmp($_SERVER['REQUEST_METHOD'], 'POST')) {
     header('Access-Control-Allow-Methods: POST', true, 405);
     exit;
@@ -35,12 +36,14 @@ try {
     
     $post = trim(file_get_contents('php://input'));
     $post = json_decode($post, true);
+    error_log(print_r(array_slice($post, 0, 2), true));
     // $post = filter_var_array($post, FILTER_SANITIZE_SPECIAL_CHARS);
 
     $postKeys = array_keys($post[1] + $post[count($post) - 1] + $post[floor((count($post) / 2))]); // grab keys from first, middle, and last element of post data
 
     if (($idIndex = array_search('ID', $postKeys)) !== false) unset($postKeys[$idIndex]); // don't try to match name of ID col
 
+    // compare POST keys to columns
     foreach ($postKeys as $key) {
         if (array_search(strtolower($key), $cols) === false) {
             header('Status: 400 Bad Request', true, 400);

--- a/api/def.php
+++ b/api/def.php
@@ -27,49 +27,27 @@ if (strcasecmp($_SERVER['REQUEST_METHOD'], 'GET')) {
     exit;
 }
 
+$pHed = [
+    'id' => '_id',
+    'location' => 'Location',
+    'severity' => 'Severity',
+    'status' => 'Status',
+    'systemAffected' => 'System Affected',
+    'groupToResolve' => 'Group to Resolve',
+    'description' => 'Description',
+    'specLoc' => 'Specific Location',
+    'requiredBy' => 'Required Prior To',
+    'dueDate' => 'Due Date',
+    'defType' => 'Type',
+    'actionOwner' => 'Action Owner',
+    'comment' => 'Comments'
+];
+$bHed = [];
+$head = [];
+
 try {
     // check Session vars against DB
     $link = new MySqliDB(DB_CREDENTIALS);
-    // $fields = [ 'username', 'userID', 'firstname', 'lastname', 'role' ];
-
-    // $link->where('userID', $_SESSION['userID']);
-    // $result = $link->getOne('users_enc', $fields);
-
-    // if ($result['username'] !== $_SESSION['username']
-    //     || $result['role'] !== $_SESSION['role']
-    //     || $result['firstname'] !== $_SESSION['firstname']
-    //     || $result['lastname'] !== $_SESSION['lastname'])
-    // {
-    //     header('Status: 403 Forbidden', true, 403);
-    //     exit;
-    // }
-
-    // if Auth ok, validate fields on first data element of POST against fields in DB
-    // note: element at index 0 is heading names, not table data
-    // $link->where('table_name', 'CDL');
-    // $link->orWhere('table_name', 'BARTDL');
-    // $cols = $link->getValue('information_schema.columns', 'column_name', null); // returns 50+ columns
-    // $cols = array_map('strtolower', $cols);
-    
-    // get raw POST input coz it's in JSON and PHP doesn't handle that well
-    // $post = trim(file_get_contents('php://input'));
-    // $post = json_decode($post, true);
-    // error_log(print_r(array_slice($post, 0, 2), true));
-    // $post = filter_var_array($post, FILTER_SANITIZE_SPECIAL_CHARS);
-
-    // $postKeys = array_keys($post[1] + $post[count($post) - 1] + $post[floor((count($post) / 2))]); // grab keys from first, middle, and last element of post data
-
-    // if (($idIndex = array_search('ID', $postKeys)) !== false) unset($postKeys[$idIndex]); // don't try to match name of ID col
-
-    // compare POST keys to columns
-    // foreach ($postKeys as $key) {
-    //     if (array_search(strtolower($key), $cols) === false) {
-    //         header('Status: 400 Bad Request', true, 400);
-    //         exit;
-    //     }
-    // }
-
-    // header('Content-Type: text/csv', true);
 
     if (empty($_GET['fields'])) {
         http_response_code(400);
@@ -128,7 +106,6 @@ try {
     }
 
     array_unshift($defs, $fields);
-    error_log('output: ' . print_r(array_slice($defs, 0, 2), true));
 
     $csv = Writer::createFromFileObject(new SplTempFileObject());
     $csv->setNewline("\r\n");

--- a/api/def.php
+++ b/api/def.php
@@ -1,10 +1,11 @@
 <?php
 use SVBX\Export;
+use League\Csv\Writer;
 
 require 'vendor/autoload.php';
 require 'session.php';
 
-// if it's not a POST you'll get a get 0 and return 'Method Not Allowed'
+// only if it's a POST will you get a 0 and bypass this statement
 if (strcasecmp($_SERVER['REQUEST_METHOD'], 'POST')) {
     header('Access-Control-Allow-Methods: POST', true, 405);
     exit;
@@ -51,9 +52,13 @@ try {
         }
     }
 
-    header('Content-Type: text/csv', true);
+    // header('Content-Type: text/csv', true);
 
-    echo Export::csv($post);
+    $csv = Writer::createFromFileObject(new SplTempFileObject());
+    $csv->setNewline("\r\n");
+    $csv->insertAll($post);
+    $csv->output("defs_summary_" . date('YmdHis') . ".csv");
+    // echo Export::csv($post);
 } catch (\Exception $e) {
     error_log($e);
     header('500 Internal server error', true, 500);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "codeguy/upload": "^1.3",
         "twig/twig": "^2.4",
         "joshcam/mysqli-database-class": "^2.9",
-        "nesbot/carbon": "^2.4"
+        "nesbot/carbon": "^2.4",
+        "league/csv": "^9.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2500e63e2e748de74043ac19b048a96b",
+    "content-hash": "907561eff4cfae1dc636b4599717a88a",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -63,12 +63,12 @@
             "version": "1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/codeguy/Upload.git",
+                "url": "https://github.com/brandonsavage/Upload.git",
                 "reference": "6a9e5e1fb58d65346d0e557db2d46fb25efd3e37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/codeguy/Upload/zipball/6a9e5e1fb58d65346d0e557db2d46fb25efd3e37",
+                "url": "https://api.github.com/repos/brandonsavage/Upload/zipball/6a9e5e1fb58d65346d0e557db2d46fb25efd3e37",
                 "reference": "6a9e5e1fb58d65346d0e557db2d46fb25efd3e37",
                 "shasum": ""
             },
@@ -330,6 +330,73 @@
             ],
             "description": "PHP MySQL Wrapper and object mapper which utilizes MySQLi and prepared statements",
             "time": "2018-02-08T05:07:59+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
+                "reference": "b574a7d8b28f1528e011d8652fb7d2e83410d4c9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=7.0.10"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "friendsofphp/php-cs-fixer": "^2.12",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpstan/phpstan-strict-rules": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Csv data manipulation made easy in PHP",
+            "homepage": "http://csv.thephpleague.com",
+            "keywords": [
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "write"
+            ],
+            "time": "2019-06-07T06:24:33+00:00"
         },
         {
             "name": "mailgun/mailgun-php",

--- a/defs.php
+++ b/defs.php
@@ -63,11 +63,13 @@ $projectTableHeadings = [
     'edit' => [ 'value' => 'Edit', 'cellWd' => '1', 'collapse' => 'sm', 'classList' => 'def-table__edit', 'href' => '/updateDef.php?id=' ]
 ];
 
-$projectCSVHeadings = array_column($projectTableHeadings, 'value')
-    + [
-        'type',
-        'comments'
-    ];
+$projectTableHeadingVals = array_column($projectTableHeadings, 'value');
+// remove 'Edit' value for downloadable content
+array_splice($projectTableHeadingVals, array_search('Edit', $projectTableHeadingVals), 1);
+$projectCSVHeadings = array_unique(
+    array_merge($projectTableHeadingVals, [ 'type', 'action owner', 'comments' ])
+);
+error_log(print_r($projectCSVHeadings, true));
 
 $bartCSVHeadings = array_column($bartTableHeadings, 'value');
 
@@ -394,12 +396,11 @@ try {
     $displayData = array_map(function($row) use ($data) {
         return array_slice($row, 0, count($row) - 3);
     }, $data);
-    // error_log(print_r(array_slice($displayData, 0, 3), true));
     $context['data'] = $displayData;
-    // $context['dataWithHeadings'] = [ array_column($context['tableHeadings'], 'value') ];
+    error_log('wtf headings? ' . print_r($csvHeadings, true));
     $context['dataWithHeadings'] = [ $csvHeadings ];
     // splice out 'Edit' for downloadable content
-    array_splice($context['dataWithHeadings'][0], array_search('Edit', $context['dataWithHeadings'][0]), 1);
+    // array_splice($context['dataWithHeadings'][0], array_search('Edit', $context['dataWithHeadings'][0]), 1);
     // rename 'ID' column because Excel is garbage
     $context['dataWithHeadings'][0][(array_search($context['dataWithHeadings'], $context['dataWithHeadings'][0]))] = 'defID';
     $context['dataWithHeadings'] = array_merge($context['dataWithHeadings'], $data);

--- a/defs.php
+++ b/defs.php
@@ -69,7 +69,6 @@ array_splice($projectTableHeadingVals, array_search('Edit', $projectTableHeading
 $projectCSVHeadings = array_unique(
     array_merge($projectTableHeadingVals, [ 'type', 'action owner', 'comments' ])
 );
-error_log(print_r($projectCSVHeadings, true));
 
 $bartCSVHeadings = array_column($bartTableHeadings, 'value');
 
@@ -397,7 +396,6 @@ try {
         return array_slice($row, 0, count($row) - 3);
     }, $data);
     $context['data'] = $displayData;
-    error_log('wtf headings? ' . print_r($csvHeadings, true));
     $context['dataWithHeadings'] = [ $csvHeadings ];
     // splice out 'Edit' for downloadable content
     // array_splice($context['dataWithHeadings'][0], array_search('Edit', $context['dataWithHeadings'][0]), 1);

--- a/defs.php
+++ b/defs.php
@@ -63,15 +63,6 @@ $projectTableHeadings = [
     'edit' => [ 'value' => 'Edit', 'cellWd' => '1', 'collapse' => 'sm', 'classList' => 'def-table__edit', 'href' => '/updateDef.php?id=' ]
 ];
 
-$projectTableHeadingVals = array_column($projectTableHeadings, 'value');
-// remove 'Edit' value for downloadable content
-array_splice($projectTableHeadingVals, array_search('Edit', $projectTableHeadingVals), 1);
-$projectCSVHeadings = array_unique(
-    array_merge($projectTableHeadingVals, [ 'type', 'action owner', 'comments' ])
-);
-
-$bartCSVHeadings = array_column($bartTableHeadings, 'value');
-
 $bartFields = [
     'ID',
     's.statusName as status',
@@ -272,9 +263,9 @@ $projectSort = [
     'dueDate' => 'Due date'
 ];
 
-list($table, $tableAlias, $addPath, $tableHeadings, $csvHeadings, $fields, $joins, $filters, $sortOptions) = $view === 'BART'
-    ? [ 'BARTDL b', 'b', 'newDef.php?class=bart', $bartTableHeadings, $bartTableHeadings, $bartFields, $bartJoins, $bartFilters, [] ]
-    : [ 'CDL c', 'c', 'newDef.php', $projectTableHeadings, $projectCSVHeadings, $projectFields, $projectJoins, $projectFilters, $projectSort ];
+list($table, $tableAlias, $addPath, $tableHeadings, $fields, $joins, $filters, $sortOptions) = $view === 'BART'
+    ? [ 'BARTDL b', 'b', 'newDef.php?class=bart', $bartTableHeadings, $bartFields, $bartJoins, $bartFilters, [] ]
+    : [ 'CDL c', 'c', 'newDef.php', $projectTableHeadings, $projectFields, $projectJoins, $projectFilters, $projectSort ];
 
 if ($_SESSION['role'] <= 10) unset($tableHeadings['edit']);
 
@@ -391,17 +382,16 @@ try {
     
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
+    error_log('got ' . count($data) . 'records');
+    error_log("records:\n" . print_r($data, true));
     // slice off last 3 columns from each result for web display
-    $displayData = array_map(function($row) use ($data) {
-        return array_slice($row, 0, count($row) - 3);
-    }, $data);
-    $context['data'] = $displayData;
-    $context['dataWithHeadings'] = [ $csvHeadings ];
-    // splice out 'Edit' for downloadable content
-    // array_splice($context['dataWithHeadings'][0], array_search('Edit', $context['dataWithHeadings'][0]), 1);
+    // $displayData = array_map(function($row) use ($data) {
+    //     return array_slice($row, 0, count($row) - 3);
+    // }, $data);
+    $context['data'] = $data;
     // rename 'ID' column because Excel is garbage
-    $context['dataWithHeadings'][0][(array_search($context['dataWithHeadings'], $context['dataWithHeadings'][0]))] = 'defID';
-    $context['dataWithHeadings'] = array_merge($context['dataWithHeadings'], $data);
+    // $context['dataWithHeadings'][0][(array_search($context['dataWithHeadings'], $context['dataWithHeadings'][0]))] = 'defID';
+    // $context['dataWithHeadings'] = array_merge($context['dataWithHeadings'], $data);
 
     $context['count'] = $link->count;
 

--- a/defs.php
+++ b/defs.php
@@ -382,8 +382,6 @@ try {
     
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
-    error_log('got ' . count($data) . 'records');
-    error_log("records:\n" . print_r($data, true));
     // slice off last 3 columns from each result for web display
     // $displayData = array_map(function($row) use ($data) {
     //     return array_slice($row, 0, count($row) - 3);

--- a/migrations/20190726041556-create-def-view.js
+++ b/migrations/20190726041556-create-def-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190726041556-create-def-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190726041556-create-def-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20190728151657-create-bart-view.js
+++ b/migrations/20190728151657-create-bart-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190728151657-create-bart-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190728151657-create-bart-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190726041556-create-def-view-down.sql
+++ b/migrations/sqls/20190726041556-create-def-view-down.sql
@@ -1,0 +1,2 @@
+/* create view deficiency DOWN */
+DROP VIEW deficiency

--- a/migrations/sqls/20190726041556-create-def-view-up.sql
+++ b/migrations/sqls/20190726041556-create-def-view-up.sql
@@ -1,6 +1,6 @@
-/* create view UP */
+/* create deficiency view UP */
 CREATE VIEW deficiency AS
-    SELECT CDL.defID AS _id,
+    SELECT CDL.defID AS id,
     loc.locationName AS location,
     sev.severityName AS severity,
     stat.statusName AS status,
@@ -14,12 +14,11 @@ CREATE VIEW deficiency AS
     CDL.actionOwner AS actionOwner,
     com.cdlCommText AS comment
     FROM CDL
-    JOIN location loc ON CDL.location = loc.locationID
-    JOIN severity sev ON CDL.severity = sev.severityID
-    JOIN status stat ON CDL.status = stat.statusID
-    JOIN system sys ON CDL.systemAffected = sys.systemID
-    JOIN system grp ON CDL.groupToResolve = grp.systemID
-    JOIN requiredBy req ON CDL.requiredBy = req.reqByID
-    JOIN defType type ON CDL.defType = type.defTypeID
-    JOIN cdlComments com ON CDL.defID = com.defID
-    ORDER BY CDL.defID
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20190726041556-create-def-view-up.sql
+++ b/migrations/sqls/20190726041556-create-def-view-up.sql
@@ -1,0 +1,25 @@
+/* create view UP */
+CREATE VIEW deficiency AS
+    SELECT CDL.defID AS _id,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment
+    FROM CDL
+    JOIN location loc ON CDL.location = loc.locationID
+    JOIN severity sev ON CDL.severity = sev.severityID
+    JOIN status stat ON CDL.status = stat.statusID
+    JOIN system sys ON CDL.systemAffected = sys.systemID
+    JOIN system grp ON CDL.groupToResolve = grp.systemID
+    JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    JOIN defType type ON CDL.defType = type.defTypeID
+    JOIN cdlComments com ON CDL.defID = com.defID
+    ORDER BY CDL.defID

--- a/migrations/sqls/20190728151657-create-bart-view-down.sql
+++ b/migrations/sqls/20190728151657-create-bart-view-down.sql
@@ -1,0 +1,2 @@
+/* Replace with your SQL commands */
+DROP VIEW bart_def;

--- a/migrations/sqls/20190728151657-create-bart-view-up.sql
+++ b/migrations/sqls/20190728151657-create-bart-view-up.sql
@@ -2,10 +2,12 @@
 CREATE VIEW bart_def AS
     SELECT ID as id,
     stat.statusName AS status,
-    date_created,
+    bart.date_created,
     descriptive_title_vta AS description,
     resolution_vta AS resolution,
-    next.nextStepName AS nextStep
+    next.nextStepName AS nextStep,
+    com.bdCommText AS comment
     FROM BARTDL bart
-    JOIN status stat ON bart.status = stat.statusID
-    JOIN bdNextStep next ON bart.next_step = next.nextStepName
+    LEFT JOIN status stat ON bart.status = stat.statusID
+    LEFT JOIN bdNextStep next ON bart.next_step = next.bdNextStepID
+    LEFT JOIN bartdlComments com ON bart.ID = com.bartdlID

--- a/migrations/sqls/20190728151657-create-bart-view-up.sql
+++ b/migrations/sqls/20190728151657-create-bart-view-up.sql
@@ -1,0 +1,11 @@
+/* create bart view UP */
+CREATE VIEW bart_def AS
+    SELECT ID as id,
+    stat.statusName AS status,
+    date_created,
+    descriptive_title_vta AS description,
+    resolution_vta AS resolution,
+    next.nextStepName AS nextStep
+    FROM BARTDL bart
+    JOIN status stat ON bart.status = stat.statusID
+    JOIN bdNextStep next ON bart.next_step = next.nextStepName

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "gulp"
+    "build": "gulp",
+    "migrate": "db-migrate",
+    "migrate:up": "npm migrate -- up",
+    "migrate:down": "npm migrate -- down"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,11 @@
 This project now (as of commit d05d25a, 4/25/2018) uses [Composer](https://getcomposer.org) to manage php dependencies
 
-It also uses [npm](https://npmsj.com) to manage [node](https://nodejs.org) dependencies, but I'm not actually using any node modules yet
+It also uses [npm](https://npmjs.com) to manage [node](https://nodejs.org) dependencies. There's a build step using [Gulp](https://gulpjs.com) that just moves front-end dependencies into the public folders.
+
+Reminder to self:
+### How I am running the thing locally
+1. Start MAMP. You can do this from the command line:
+```bash
+$ mampstart
+```
+2. MAMP will open your default browser to a MAMP start page. I have an Apache virtual host setup to serve the project at a local subdomain. Point your browser to svbx.localhost:8888

--- a/session.php
+++ b/session.php
@@ -3,14 +3,14 @@ session_start();
 
 if (empty($_SESSION['userID'])) {
     /* Redirect If Not Logged In */
-    header("Location: login.php");
+    header("Location: /login.php");
     exit; /* prevent other code from being executed*/
 } else {
   $timeout = defined('TIMEOUT') ? TIMEOUT : 15;
   // check for session timeout
   if ($_SESSION['timeout'] + $timeout * 60 < time()) {
     /* session timed out */
-    header("Location: logout.php");
+    header("Location: /logout.php");
   } else {
     /*if the user isn't timed out, update the session timeout variable to the current time.*/
      $_SESSION['timeout'] = time();

--- a/src/Export.php
+++ b/src/Export.php
@@ -10,13 +10,13 @@ class Export {
 
     private static function str_putcsv(array $input, $delimiter = ',', $enclosure = '"') {
         $pointer = fopen('php://temp', 'r+b'); // open memory stream with read/write permission and binary mode on
-        foreach ($input as $line) {
+        foreach ($input as $row) {
             $line = array_map(function($el) {
                 return trim(html_entity_decode($el, ENT_QUOTES, 'utf-8'));
-            }, $line);
+            }, $row);
             fputcsv($pointer, $line, $delimiter, $enclosure); // puts a single line
         }
-        rewind($pointer);
+        rewind($pointer); // rewind before right trim
         $data = rtrim(stream_get_contents($pointer), "\n"); // trim whitespace
         fclose($pointer);
         return $data;

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -46,33 +46,36 @@
         document.getElementById('getCsvBtn').addEventListener('click', event => {
             const json = JSON.stringify({{ dataWithHeadings | json_encode | raw }})
             console.log(JSON.parse(json))
-            fetch('/api/def.php', {
-                method: 'POST',
-                body: json,
+            querystring = 'fields=id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment&range=0,10'
+            url = '/api/def.php?' + querystring
+            fetch(url, {
                 credentials: 'same-origin',
                 headers: {
                     'Content-type': 'application/json',
                     'Accept': 'text/csv'
                 }
             }).then(res => {
-                if (!res.ok) throw res
+                if (!res.ok) {
+                    console.error(`${res.status}: ${res.statusText}`)
+                    throw res.text()
+                }
                 return res.text()
             }).then(text => {
                 const d = new Date()
                 const timestamp = d.getFullYear()
                     + '' + (d.getMonth() + 1)
                     + '' + d.getDate()
-                    + '' + d.getHours()
-                    + '' + d.getMinutes()
-                    + '' + d.getSeconds()
+                    + '' + (d.getHours() < 10 ? '0' + d.getHours() : d.getHours())
+                    + '' + (d.getMinutes() < 10 ? '0' + d.getMinutes() : d.getMinutes())
+                    + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
                 download(text, `defs_summary_${timestamp}.csv`, 'text/csv')
             }).catch(err => {
                 if (typeof err.then === 'function') {
-                    err.text().then(text => {
+                    err.then(text => {
                         console.error(text)
                     })
                 }
-                else console.err(err)
+                else console.error(err)
             })
         })
     {% if view is same as('BART') %}

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -45,6 +45,7 @@
         })
         document.getElementById('getCsvBtn').addEventListener('click', event => {
             const json = JSON.stringify({{ dataWithHeadings | json_encode | raw }})
+            console.log(JSON.parse(json))
             fetch('/api/def.php', {
                 method: 'POST',
                 body: json,
@@ -66,7 +67,11 @@
                     + '' + d.getSeconds()
                 download(text, `defs_summary_${timestamp}.csv`, 'text/csv')
             }).catch(err => {
-                if (err.status) console.err(`${err.status} ${res.statusText} ${res.url}`)
+                if (typeof err.then === 'function') {
+                    err.text().then(text => {
+                        console.error(text)
+                    })
+                }
                 else console.err(err)
             })
         })

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -44,7 +44,15 @@
             })
         })
         document.getElementById('getCsvBtn').addEventListener('click', event => {
-            querystring = 'fields=id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment&range=0,10'
+            let view
+            querystring = 'fields='
+            {% if view is same as('BART') %}
+            querystring += 'id,status,date_created,description,resolution,nextStep,comment'
+            querystring += '&view=BART'
+            view = 'bart'
+            {% else %}
+            querystring += 'id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
+            {% endif %}
             url = '/api/def.php?' + querystring
             fetch(url, {
                 credentials: 'same-origin',
@@ -63,7 +71,7 @@
                     + '' + (d.getHours() < 10 ? '0' + d.getHours() : d.getHours())
                     + '' + (d.getMinutes() < 10 ? '0' + d.getMinutes() : d.getMinutes())
                     + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
-                download(text, `defs_summary_${timestamp}.csv`, 'text/csv')
+                download(text, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
             }).catch(err => {
                 if (typeof err.then === 'function') {
                     err.then(text => {

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -44,16 +44,11 @@
             })
         })
         document.getElementById('getCsvBtn').addEventListener('click', event => {
-            const json = JSON.stringify({{ dataWithHeadings | json_encode | raw }})
-            console.log(JSON.parse(json))
             querystring = 'fields=id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment&range=0,10'
             url = '/api/def.php?' + querystring
             fetch(url, {
                 credentials: 'same-origin',
-                headers: {
-                    'Content-type': 'application/json',
-                    'Accept': 'text/csv'
-                }
+                headers: { 'Accept': 'text/csv' }
             }).then(res => {
                 if (!res.ok) {
                     console.error(`${res.status}: ${res.statusText}`)

--- a/templates/head.html.twig
+++ b/templates/head.html.twig
@@ -4,5 +4,4 @@
 <meta name="author" content="">
 <title>SVBX - {{ title }}</title>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-<link rel="stylesheet" href="assets/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 <link rel="stylesheet" type="text/css" href="/styles2.css?v=15490413744108"/>

--- a/templates/head.html.twig
+++ b/templates/head.html.twig
@@ -4,4 +4,5 @@
 <meta name="author" content="">
 <title>SVBX - {{ title }}</title>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+<link rel="stylesheet" href="assets/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 <link rel="stylesheet" type="text/css" href="/styles2.css?v=15490413744108"/>


### PR DESCRIPTION
`/api/def.php` will now take a query string of `fields`, `range`, and `view`, and return CSV of the specified fields for the specified SQL view

If `comments` is specified in `fields`, collects all comments together onto one line in separate columns so that deficiencies do not repeat when deficiency has more than one comment (as the one-to-many relationship of defs => comments will return multiple rows from a SQL query)