### PR TITLE
restore ability to apply filters from view to downloaded csv

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -91,7 +91,6 @@ try {
         unset($get['range']);
     }
 
-    error_log(print_r($get, true));
     if (!empty($get)) {
         $filters = [];
         foreach ($get as $key => $val) {
@@ -103,8 +102,6 @@ try {
 
     $link->orderBy('id', 'ASC');
     $defs = $link->get($view, null, $fields);
-    if (!empty($filters))
-        error_log("query after filtering defs API:\n" . $link->getLastQuery());
 
     // if comments included, combine defs and put comments in extra cols
     if (array_search('comment', $fields) !== false) {

--- a/api/def.php
+++ b/api/def.php
@@ -91,17 +91,27 @@ try {
         unset($get['range']);
     }
 
+    // filter defs with remaining GET params
     if (!empty($get)) {
+        error_log("GET params to filter on\n" . print_r($get, true));
         $filters = [];
         foreach ($get as $key => $val) {
-            $link->where($key, $val);
-            $filters[] = $get[$key];
+            error_log($key . ' => ' . $val);
+            if (strcasecmp($key, 'identifiedby') === 0
+            || strcasecmp($key, 'specloc') === 0) {
+                $link->where($key, "%{$val}%", 'LIKE');
+            }
+            else $link->where($key, $val);
+            $filters[] = [ $key, $val ];
             unset($get[$key]);
         }
     }
 
     $link->orderBy('id', 'ASC');
     $defs = $link->get($view, null, $fields);
+    error_log("query\n" . $link->getLastQuery());
+    if (!empty($filters))
+        error_log("defs\n" . print_r($defs, true));
 
     // if comments included, combine defs and put comments in extra cols
     if (array_search('comment', $fields) !== false) {

--- a/defs.php
+++ b/defs.php
@@ -382,6 +382,7 @@ try {
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
     $context['data'] = $data;
+    error_log("query\n" . $link->getLastQuery());
 
     $context['count'] = $link->count;
 

--- a/defs.php
+++ b/defs.php
@@ -10,11 +10,9 @@ $orderBy = null;
 // check for search params
 // if no search params show all defs that are not 'deleted'
 if(!empty($_GET)) {
-    error_log("\$_GET before filtering:\n" . print_r($_GET, true));
     $get = array_filter($_GET, function ($val) {
         return (gettype($val) === 'string' && $val !== '') || (bool) $val;
     }); // filter to remove falsey values -- is this necessary?
-    error_log("\$_GET after filtering:\n" . print_r($get, true));
     unset($get['search'], $get['view']);
     $get = filter_var_array($get, FILTER_SANITIZE_SPECIAL_CHARS);
     $orderBy = array_reduce(array_keys($get), function($acc, $key) use ($get) {
@@ -355,7 +353,6 @@ try {
 
     // filter on user-selected query params
     if (!empty($get)) {
-        error_log("filters params:\n" . print_r($get, true));
         foreach ($get as $param => $val) {
             if ($param === 'description'
                 || $param === 'defID'
@@ -385,8 +382,6 @@ try {
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
     $context['data'] = $data;
-    if (!empty($get))
-        error_log("query after filtering defs view:\n" . $link->getLastQuery());
 
     $context['count'] = $link->count;
 

--- a/defs.php
+++ b/defs.php
@@ -10,7 +10,11 @@ $orderBy = null;
 // check for search params
 // if no search params show all defs that are not 'deleted'
 if(!empty($_GET)) {
-    $get = array_filter($_GET); // filter to remove falsey values -- is this necessary?
+    error_log("\$_GET before filtering:\n" . print_r($_GET, true));
+    $get = array_filter($_GET, function ($val) {
+        return (gettype($val) === 'string' && $val !== '') || (bool) $val;
+    }); // filter to remove falsey values -- is this necessary?
+    error_log("\$_GET after filtering:\n" . print_r($get, true));
     unset($get['search'], $get['view']);
     $get = filter_var_array($get, FILTER_SANITIZE_SPECIAL_CHARS);
     $orderBy = array_reduce(array_keys($get), function($acc, $key) use ($get) {
@@ -136,7 +140,7 @@ $bartFilters = [
         'fields' => ['partyID', 'partyName'],
         'join' => [
             'joinTable' => 'BARTDL b',
-            'joinOn' => 'p.partyID = b.creator',
+            'joinOn' => 'p.partyID = b.bic',
             'joinType' => 'INNER'
         ],
         'groupBy' => 'p.partyID',
@@ -350,7 +354,8 @@ try {
     }
 
     // filter on user-selected query params
-    if ($get) {
+    if (!empty($get)) {
+        error_log("filters params:\n" . print_r($get, true));
         foreach ($get as $param => $val) {
             if ($param === 'description'
                 || $param === 'defID'
@@ -379,14 +384,9 @@ try {
     
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
-    // slice off last 3 columns from each result for web display
-    // $displayData = array_map(function($row) use ($data) {
-    //     return array_slice($row, 0, count($row) - 3);
-    // }, $data);
     $context['data'] = $data;
-    // rename 'ID' column because Excel is garbage
-    // $context['dataWithHeadings'][0][(array_search($context['dataWithHeadings'], $context['dataWithHeadings'][0]))] = 'defID';
-    // $context['dataWithHeadings'] = array_merge($context['dataWithHeadings'], $data);
+    if (!empty($get))
+        error_log("query after filtering defs view:\n" . $link->getLastQuery());
 
     $context['count'] = $link->count;
 

--- a/migrations/20190802044917-add-filter-cols-bart-view.js
+++ b/migrations/20190802044917-add-filter-cols-bart-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190802044917-add-filter-cols-bart-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190802044917-add-filter-cols-bart-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20190802055757-add-filter-cols-def-view.js
+++ b/migrations/20190802055757-add-filter-cols-def-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190802055757-add-filter-cols-def-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190802055757-add-filter-cols-def-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190802044917-add-filter-cols-bart-view-down.sql
+++ b/migrations/sqls/20190802044917-add-filter-cols-bart-view-down.sql
@@ -1,0 +1,13 @@
+/* Replace with your SQL commands */
+ALTER VIEW bart_def AS
+    SELECT ID as id,
+    stat.statusName AS status,
+    bart.date_created,
+    descriptive_title_vta AS description,
+    resolution_vta AS resolution,
+    next.nextStepName AS nextStep,
+    com.bdCommText AS comment
+    FROM BARTDL bart
+    LEFT JOIN status stat ON bart.status = stat.statusID
+    LEFT JOIN bdNextStep next ON bart.next_step = next.bdNextStepID
+    LEFT JOIN bartdlComments com ON bart.ID = com.bartdlID

--- a/migrations/sqls/20190802044917-add-filter-cols-bart-view-down.sql
+++ b/migrations/sqls/20190802044917-add-filter-cols-bart-view-down.sql
@@ -1,4 +1,4 @@
-/* Replace with your SQL commands */
+/* ADD bic, safety_cert_vta, resolution_disputed, structural DOWN */
 ALTER VIEW bart_def AS
     SELECT ID as id,
     stat.statusName AS status,

--- a/migrations/sqls/20190802044917-add-filter-cols-bart-view-up.sql
+++ b/migrations/sqls/20190802044917-add-filter-cols-bart-view-up.sql
@@ -1,0 +1,17 @@
+/* ADD bic, safety_cert_vta, resolution_disputed, structural UP */
+ALTER VIEW bart_def AS
+    SELECT ID as id,
+    stat.statusName AS status,
+    bart.date_created,
+    descriptive_title_vta AS description,
+    resolution_vta AS resolution,
+    next.nextStepName AS nextStep,
+    com.bdCommText AS comment,
+    bic,
+    safety_cert_vta,
+    resolution_disputed,
+    structural
+    FROM BARTDL bart
+    LEFT JOIN status stat ON bart.status = stat.statusID
+    LEFT JOIN bdNextStep next ON bart.next_step = next.bdNextStepID
+    LEFT JOIN bartdlComments com ON bart.ID = com.bartdlID

--- a/migrations/sqls/20190802055757-add-filter-cols-def-view-down.sql
+++ b/migrations/sqls/20190802055757-add-filter-cols-def-view-down.sql
@@ -1,0 +1,24 @@
+/* ADD safetyCert, identifiedBy to def view DOWN */
+ALTER VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20190802055757-add-filter-cols-def-view-up.sql
+++ b/migrations/sqls/20190802055757-add-filter-cols-def-view-up.sql
@@ -1,0 +1,26 @@
+/* ADD safetyCert, identifiedBy to def view UP */
+ALTER VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment,
+    safetyCert,
+    identifiedBy
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -53,6 +53,7 @@
                 .slice(1)
                 .replace('view=bart', '')
             filters = filters.startsWith('&') ? filters : `&${filters}`
+            filters = filters.replace('defid', 'id')
             const querystring = '?fields=' + fields + filters
             const url = '/api/def.php' + querystring
             fetch(url, {

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -48,10 +48,11 @@
             const fields = view && view === 'BART'
                 ? 'id,status,date_created,description,resolution,nextStep,comment&view=BART'
                 : 'id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
-            const filters = window.location.search
+            let filters = window.location.search
                 .toLowerCase()
                 .slice(1)
                 .replace('view=bart', '')
+            filters = filters.startsWith('&') ? filters : `&${filters}`
             const querystring = '?fields=' + fields + filters
             const url = '/api/def.php' + querystring
             fetch(url, {
@@ -84,7 +85,6 @@
         function getQueryValue(key) {
             if (!window.location.search) return false
             const qs = qsToObj()
-            console.log(qs)
             if (key in qs) return qs[key]
             return false
         }

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -34,7 +34,7 @@
     <script src="js/pie_chart.js"></script>
     <script>
         document.forms.filterForm.addEventListener('submit', {{submitScript.function | default("unnameEmptyFormControls") | raw}})
-        document.getElementById('reset').addEventListener('click', ev => {
+        document.getElementById('reset-btn').addEventListener('click', ev => {
             {{resetScript.function | default("resetSearch") | raw}}(ev)
         })
         document.querySelectorAll('select[name^="sort_"]').forEach((select, i, collection) => {
@@ -44,16 +44,16 @@
             })
         })
         document.getElementById('getCsvBtn').addEventListener('click', event => {
-            let view
-            querystring = 'fields='
-            {% if view is same as('BART') %}
-            querystring += 'id,status,date_created,description,resolution,nextStep,comment'
-            querystring += '&view=BART'
-            view = 'bart'
-            {% else %}
-            querystring += 'id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
-            {% endif %}
-            url = '/api/def.php?' + querystring
+            const view = getQueryValue('view')
+            const fields = view && view === 'BART'
+                ? 'id,status,date_created,description,resolution,nextStep,comment&view=BART'
+                : 'id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
+            const filters = window.location.search
+                .toLowerCase()
+                .slice(1)
+                .replace('view=bart', '')
+            const querystring = '?fields=' + fields + filters
+            const url = '/api/def.php' + querystring
             fetch(url, {
                 credentials: 'same-origin',
                 headers: { 'Accept': 'text/csv' }
@@ -81,6 +81,24 @@
                 else console.error(err)
             })
         })
+        function getQueryValue(key) {
+            if (!window.location.search) return false
+            const qs = qsToObj()
+            console.log(qs)
+            if (key in qs) return qs[key]
+            return false
+        }
+        function qsToObj() {
+            if (!window.location.search) return false
+            return window.location.search
+                .slice(1)
+                .split('&')
+                .reduce((o, prop) => {
+                    const [ key, val ] = prop.split('=')
+                    o[key] = val
+                    return o
+                }, {})
+        }
     {% if view is same as('BART') %}
         const openCloseChart = new PieChart(
                 window.d3,

--- a/templates/filterForm.html.twig
+++ b/templates/filterForm.html.twig
@@ -28,7 +28,7 @@
         {% include "includes/sortControls.html.twig" with sortOptions %}
         <div id="container_buttons_submit-reset" class="">
             <button type="submit" class="btn btn-primary item-margin-right">{{formBtnText | default('Search')}}</button>
-            <button type="button" class="btn btn-primary item-margin-right" id="reset">Reset</button>
+            <button type="button" class="btn btn-primary item-margin-right" id="reset-btn">Reset</button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
This took some serious wrangling, and it's not very good because it's late at night and I'm tired. It's basically a god-awful chain of finicky if-else statements handling all kinds of special cases because the tables have highly variable field names, and the SQL views I created for Defs only grab names, not numerical IDs so I had to map the names back to the their numerical IDs since filters on the frontend are done with the IDs as they exist in the two Defs tables.

Blugh. I got it done. I know how it ought to work: instead of a SQL view, I ought to implement a DefsCollection class that can filter the Defs objects it contains. But whenever will there be time for that? Probably never.

I'm going to ship this in the morning because the deploy flow on this project is crazy and janky and it's too late at night and I'm too tired to get it all right.