### PR TITLE
fix requiredBy filter

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -139,10 +139,8 @@ try {
                     return $dict;
                 }, []);
                 $link->where('nextStep', $lookup[$val]);
-            } elseif (strcasecmp($key, 'safetyCert') === 0) {
-                // safety cert is the only one that's not a join
-                $link->where($key, $val);
-            } elseif ($view === 'deficiency'
+            } elseif (($view === 'deficiency'
+            && strcasecmp($key, 'safetyCert') !== 0)
             || strcasecmp($key, 'status') === 0) {
                 $table = $key;
                 $id = "{$table}ID";

--- a/api/def.php
+++ b/api/def.php
@@ -93,7 +93,6 @@ try {
 
     // filter defs with remaining GET params
     if (!empty($get)) {
-        $filters = [];
         foreach ($get as $key => $val) {
             if (strcasecmp($key, 'identifiedby') === 0
             || strcasecmp($key, 'specloc') === 0
@@ -117,8 +116,8 @@ try {
                     $arrayVals[] = $system[$extraVal];
                 }
                 $link->where($key, $arrayVals, 'IN');
-            } elseif (strcasecmp($key, 'requiredby') === 0) {
-                $table = $key;
+            } elseif (strcasecmp($key, 'requiredBy') === 0) {
+                $table = 'requiredBy'; // mind the capitalization
                 $id = 'reqById';
                 $name = 'requiredBy';
                 $link2 = new MySqliDB(DB_CREDENTIALS);
@@ -134,13 +133,11 @@ try {
                 $name = 'nextStepName';
                 $link2 = new MySqliDB(DB_CREDENTIALS);
                 $temp = $link2->get($table, null, [ $id, $name ]);
-                error_log("why is there a 0 val for next_step?\n" . print_r($temp, true));
                 $link2->disconnect();
                 $lookup = array_reduce($temp, function ($dict, $row) use ($id, $name) {
                     $dict[$row[$id]] = $row[$name];
                     return $dict;
                 }, []);
-                error_log("$key lookup\n" . print_r($lookup, true));
                 $link->where('nextStep', $lookup[$val]);
             } elseif (strcasecmp($key, 'safetyCert') === 0) {
                 // safety cert is the only one that's not a join
@@ -158,8 +155,9 @@ try {
                     return $dict;
                 }, []);
                 $link->where($key, $lookup[$val]);
+            } else {
+                $link->where($key, $val);
             }
-            $filters[] = [ $key, $val ];
             unset($get[$key]);
         }
     }

--- a/defs.php
+++ b/defs.php
@@ -382,7 +382,6 @@ try {
     // fetch table data and append it to $context for display by Twig template
     $data = $result = $link->get($table, null, $queryParams['fields']);
     $context['data'] = $data;
-    error_log("query\n" . $link->getLastQuery());
 
     $context['count'] = $link->count;
 


### PR DESCRIPTION
"requiredBy" filter is broken in production because linux respects letter case, whereas my computer's default file system does not. (I really need to reformat to use case-sensitive file system)

Changes the capitalization of 'requiredby' in the /api/def.php filters to 'requiredBy'

Also adds an `else` case to catch filters that do not require a join to another table