### PR TITLE
allow Def class to show status vals other than open/closed

### DIFF
--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -177,11 +177,8 @@ class Deficiency
             'where' => [
                 [
                     'field' => 'statusName',
-                    'value' => 'open'
-                ],
-                [
-                    'field' => 'statusName',
-                    'value' => 'closed'
+                    'value' => 'deleted',
+                    'comparison' => '!='
                 ]
             ]
         ],
@@ -441,8 +438,10 @@ class Deficiency
                 if (!empty($lookup['where'])) {
                     $i = 0;
                     foreach ($lookup['where'] as $where) {
-                        if ($i === 0) $link->where($where['field'], $where['value']);
-                        else $link->orWhere($where['field'], $where['value']);
+                        $comparator = $where['comparison'] ?: '=';
+                        $whereMethod = $i === 0 ? 'where' : 'orWhere';
+                        if ($i === 0) $link->where($where['field'], $where['value'], $comparator);
+                        else $link->orWhere($where['field'], $where['value'], $comparator);
                         $i++;
                     }
                 }


### PR DESCRIPTION
Currently the Deficiency class grabs from the db statuses only equal to the strings 'open' and 'closed' so as to avoid showing an option, 'deleted', to the user. JJ has added a new status. Flip it so that the Def class instead fetches statuses where string !== 'deleted', so that we will grab all allowable statuses rather than only 2 specific ones.