### PR TITLE
Create report showing open defs for date range, by severity or system

### DIFF
--- a/api/report.php
+++ b/api/report.php
@@ -33,9 +33,10 @@ try {
         $_GET['to'],
         $_GET['from'],
         $_GET['milestone']
-    )->get();
-    $headings = array_keys($report[0]);
-    array_unshift($report, $headings);
+    )->getWithHeadings();
+    // $headings = array_keys($report[0]);
+    // array_unshift($report, $headings);
+    error_log('data with headings from /report api ' . print_r($report, true));
 
     echo Export::$format($report);
 } catch (\UnexpectedValueException $e) {

--- a/api/report.php
+++ b/api/report.php
@@ -28,7 +28,12 @@ try {
     $format = $_GET['format'];
     $reportType = $_GET['type'];
 
-    $report = Report::delta($_GET['milestone'])->get();
+    $report = Report::delta(
+        $_GET['field'],
+        $_GET['to'],
+        $_GET['from'],
+        $_GET['milestone']
+    )->get();
     $headings = array_keys($report[0]);
     array_unshift($report, $headings);
 

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "ckingbailey/svbx",
     "require": {
         "mailgun/mailgun-php": "^2.5",
         "php-http/guzzle6-adapter": "^1.1",
@@ -19,6 +20,6 @@
         "phpunit/phpunit": "^8"
     },
     "scripts": {
-        "test": "phpunit --testdox tests"
+        "test": "PHP_ENV=testing phpunit --testdox tests"
     }
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -59,8 +59,12 @@ $twig = new Twig_Environment($loader, [
 ]);
 if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug());
 
-// instantiate report object
-$sit3delta = Report::delta('SIT3');
-$context['data']['weeklyReport'] = $sit3delta->get();
+$context['data']['milestones'] = $link->get('requiredBy', null, [ 'reqByID as id', 'requiredBy as name' ]);
+error_log('milestons: ' . print_r($context['data']['milestones'], true));
 
+// instantiate report object
+$sit3delta = Report::delta();
+$context['data']['deltaReport'] = $sit3delta->get();
+
+$link->disconnect();
 $twig->display('dashboard.html.twig', $context);

--- a/dashboard.php
+++ b/dashboard.php
@@ -7,13 +7,14 @@ require 'vendor/autoload.php';
 require 'WeeklyDelta.php';
 require 'session.php';
 
+// init context with some defaults
 $context = [
   'session' => $_SESSION,
   'title' => 'Home',
   'pageHeading' => 'Database Information',
   'data' => [
     'selected' => [
-      'field' => 'system',
+      'field' => 'severity',
       'from' => null,
       'to' => null,
       'milestone' => null
@@ -88,6 +89,7 @@ if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug())
 $context['data']['milestones'] = $link->get('requiredBy', null, [ 'reqByID as id', 'requiredBy as name' ]);
 
 // instantiate report object
+error_log('selected: ' . print_r($context['data']['selected'], true));
 $report = Report::delta(
   $context['data']['selected']['field'],
   $context['data']['selected']['from'],

--- a/dashboard.php
+++ b/dashboard.php
@@ -33,7 +33,7 @@ $context['data']['system'] = $link->
   // where('CDL.status', '3', '<>')->
   join('CDL', 'system.systemID = CDL.groupToResolve', 'LEFT')->
   join('users_enc', 'system.lead = users_enc.userid', 'LEFT')->
-  get('system', null, ['systemName', 'COUNT(IF(status = 1, 1, NULL)) as count', 'CONCAT(SUBSTR(firstname, 1, 1), " ", lastname) as lead']);
+  get('system', null, ['systemName', 'COUNT(IF(status = 1, 1, NULL)) as count']);
 
 $context['data']['location'] = $link->  
   orderBy('locationName', 'ASC')->

--- a/dashboard.php
+++ b/dashboard.php
@@ -89,7 +89,6 @@ if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug())
 $context['data']['milestones'] = $link->get('requiredBy', null, [ 'reqByID as id', 'requiredBy as name' ]);
 
 // instantiate report object
-error_log('selected: ' . print_r($context['data']['selected'], true));
 $report = Report::delta(
   $context['data']['selected']['field'],
   $context['data']['selected']['from'],

--- a/src/Report.php
+++ b/src/Report.php
@@ -91,15 +91,15 @@ class Report {
                     if (!is_array($having)) throw new \UnexpectedValueException(
                         'Invalid type, '
                         . gettype($having)
-                        . ' for having clause, '
+                        . ', for having clause, '
                         . print_r($having, true)
                     );
-                    elseif ((is_array($having)
+                    if ((is_array($having)
                     && !empty($invalid = array_filter(
                         $having,
                         function ($clause) { return !is_array($clause); }
                     )))) throw new \UnexpectedValueException(
-                        'Having conditions array contains mixed values, '
+                        'Having conditions array contains non-array values, '
                         . print_r($invalid, true)
                     );
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -47,7 +47,10 @@ class Report {
             "COUNT(IF(status = 1, defID, NULL)) as toDate" // need to allow the `to` range to be set
         ];
         
-        $where = [ [ 'status', '3', '<>'] ];
+        $where = [
+            [ 'CDL.dateCreated', $to, '<='],
+            [ 'status', '3', '<>']
+        ];
 
         // grab ID of by milestone name from db, if milestone provided
         if (!empty($milestone))

--- a/src/Report.php
+++ b/src/Report.php
@@ -23,7 +23,7 @@ class Report {
         $countOpenFromDate = 'COUNT(CASE'
             . ' WHEN (CDL.dateCreated <= CAST("%1$s" AS DATE)'
             . ' && (status = "1" || dateClosed > CAST("%1$s" AS DATE))) THEN defID'
-            . ' ELSE NULL END) AS fromDate';
+            . ' ELSE NULL END) AS %2$s';
         $toDate = new CarbonImmutable($to ?: date('Y-m-d'));
         $fromDate = ($from ?
             new CarbonImmutable($from)
@@ -48,8 +48,8 @@ class Report {
         
         $fields = [
             $params[$field]['select'],
-            sprintf($countOpenFromDate, $fromDate),
-            "COUNT(IF(status = 1, defID, NULL)) as toDate" // need to allow the `to` range to be set
+            sprintf($countOpenFromDate, $fromDate, 'fromDate'),
+            sprintf($countOpenFromDate, $toDate, 'toDate') // "COUNT(IF(status = 1, defID, NULL)) as toDate" // need to allow the `to` range to be set
         ];
         
         $where = [

--- a/src/Report.php
+++ b/src/Report.php
@@ -19,9 +19,9 @@ class Report {
     private $where = [];
     private $groupBy = null;
 
-    public static function delta($field = 'severity', $to = null, $from = null, $milestone = null) {
+    public static function delta($field = 'severity', $from = null, $to = null, $milestone = null) {
         $countOpenFromDate = 'COUNT(CASE'
-            . ' WHEN (CDL.dateCreated < CAST("%1$s" AS DATE)'
+            . ' WHEN (CDL.dateCreated <= CAST("%1$s" AS DATE)'
             . ' && (status = "1" || dateClosed > CAST("%1$s" AS DATE))) THEN defID'
             . ' ELSE NULL END) AS fromDate';
         $toDate = new CarbonImmutable($to ?: date('Y-m-d'));

--- a/src/Report.php
+++ b/src/Report.php
@@ -47,7 +47,7 @@ class Report {
             ]
         ];
 
-        $headings = [ $field, $fromDate, $toDate, $milestone ];
+        $headings = [ $field, $fromDate, $toDate ];
         
         $fields = [
             $params[$field]['select'],
@@ -64,6 +64,9 @@ class Report {
         ];
 
         if (!empty($milestone)) {
+            $heading = 'required by';
+            $headings[] = $heading;
+            $fields[] = "$milestone as '$heading'";
             $where[] = [ 'requiredBy', $milestone, '<='];
         }
         

--- a/src/Report.php
+++ b/src/Report.php
@@ -51,7 +51,7 @@ class Report {
 
         // grab ID of by milestone name from db, if milestone provided
         if (!empty($milestone))
-            $where[] = [ 'requiredBy', $reqByID, '<='];
+            $where[] = [ 'requiredBy', $milestone, '<='];
         
         return new Report('CDL', $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
     }    

--- a/src/Report.php
+++ b/src/Report.php
@@ -57,8 +57,9 @@ class Report {
             [ 'status', '3', '<>']
         ];
 
-        if (!empty($milestone))
+        if (!empty($milestone)) {
             $where[] = [ 'requiredBy', $milestone, '<='];
+        }
         
         return new self('CDL', $headings, $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
     }    
@@ -122,7 +123,7 @@ class Report {
     }
 
     public function __toString() {
-        print_r($this->get(), true);
+        return print_r($this->get(), true);
     }
 
 }

--- a/src/Report.php
+++ b/src/Report.php
@@ -51,7 +51,7 @@ class Report {
         ];
         
         $where = [
-            [ 'CDL.dateCreated', $to, '<='],
+            [ 'CDL.dateCreated', $toDate->format('Y-m-d'), '<='],
             [ 'status', '3', '<>']
         ];
 

--- a/src/Report.php
+++ b/src/Report.php
@@ -64,7 +64,7 @@ class Report {
         ];
 
         if (!empty($milestone)) {
-            $heading = 'required by';
+            $heading = 'milestone';
             $headings[] = $heading;
             $fields[] = "$milestone as '$heading'";
             $where[] = [ 'requiredBy', $milestone, '<='];

--- a/src/Report.php
+++ b/src/Report.php
@@ -31,6 +31,9 @@ class Report {
 
         $toDate = $toDate->toDateString();
 
+        if ($toDate < $fromDate)
+            throw new \UnexpectedValueException("End date, $toDate, is less that start date, $fromDate");
+
         $params = [
             'severity' => [
                 'select' => 'severityName AS fieldName',

--- a/src/Report.php
+++ b/src/Report.php
@@ -29,6 +29,8 @@ class Report {
             new CarbonImmutable($from)
             : $toDate->subWeek())->toDateString();
 
+        $toDate = $toDate->toDateString();
+
         $params = [
             'severity' => [
                 'select' => 'severityName AS fieldName',
@@ -42,7 +44,7 @@ class Report {
             ]
         ];
 
-        $headings = [ $field, $to, $from, $milestone ];
+        $headings = [ $field, $fromDate, $toDate, $milestone ];
         
         $fields = [
             $params[$field]['select'],
@@ -51,11 +53,10 @@ class Report {
         ];
         
         $where = [
-            [ 'CDL.dateCreated', $toDate->format('Y-m-d'), '<='],
+            [ 'CDL.dateCreated', $toDate, '<='],
             [ 'status', '3', '<>']
         ];
 
-        // grab ID of by milestone name from db, if milestone provided
         if (!empty($milestone))
             $where[] = [ 'requiredBy', $milestone, '<='];
         

--- a/src/Report.php
+++ b/src/Report.php
@@ -20,7 +20,7 @@ class Report {
     private $groupBy = null;
 
     public static function delta($field = 'severity', $to = null, $from = null, $milestone = null) {
-        $openLastWeek = 'COUNT(CASE'
+        $countOpenFromDate = 'COUNT(CASE'
             . ' WHEN (CDL.dateCreated < CAST("%1$s" AS DATE)'
             . ' && (status = "1" || dateClosed > CAST("%1$s" AS DATE))) THEN defID'
             . ' ELSE NULL END) AS fromDate';
@@ -46,7 +46,7 @@ class Report {
         
         $fields = [
             $params[$field]['select'],
-            sprintf($openLastWeek, $fromDate),
+            sprintf($countOpenFromDate, $fromDate),
             "COUNT(IF(status = 1, defID, NULL)) as toDate" // need to allow the `to` range to be set
         ];
         
@@ -59,7 +59,7 @@ class Report {
         if (!empty($milestone))
             $where[] = [ 'requiredBy', $milestone, '<='];
         
-        return new Report('CDL', $headings, $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
+        return new self('CDL', $headings, $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
     }    
     
     private function __construct($table = null, $headings = [], $fields = [], $join = null, $where = null, $groupBy = null) {

--- a/src/Report.php
+++ b/src/Report.php
@@ -22,7 +22,7 @@ class Report {
         $openLastWeek = 'COUNT(CASE'
             . ' WHEN (CDL.dateCreated < CAST("%1$s" AS DATE)'
             . ' && (status = "1" || dateClosed > CAST("%1$s" AS DATE))) THEN defID'
-            . ' ELSE NULL END) AS openLastWeek';
+            . ' ELSE NULL END) AS fromDate';
         $toDate = new CarbonImmutable($to ?: date('Y-m-d'));
         $fromDate = ($from ?
             new CarbonImmutable($from)
@@ -30,12 +30,12 @@ class Report {
 
         $params = [
             'severity' => [
-                'select' => 'severityName AS severity',
+                'select' => 'severityName AS fieldName',
                 'join' => [ 'severity', 'severity = severity.severityID' ],
                 'groupBy' => 'severity'
             ],
             'system' => [
-                'select' => 'systemName AS system',
+                'select' => 'systemName AS fieldName',
                 'join' => [ 'system', 'groupToResolve = system.systemID' ],
                 'groupBy' => 'groupToResolve'
             ]
@@ -44,7 +44,7 @@ class Report {
         $fields = [
             $params[$field]['select'],
             sprintf($openLastWeek, $fromDate),
-            "COUNT(IF(status = 1, defID, NULL)) as openThisWeek"
+            "COUNT(IF(status = 1, defID, NULL)) as toDate" // need to allow the `to` range to be set
         ];
         
         $where = [ [ 'status', '3', '<>'] ];

--- a/src/Report.php
+++ b/src/Report.php
@@ -13,12 +13,13 @@ class Report {
     private $lastQuery = '';
 
     private $table = null;
+    private $headings = [];
     private $fields = [];
     private $join = [];
     private $where = [];
     private $groupBy = null;
 
-    public static function delta($field = 'system', $to = null, $from = null, $milestone = null) {
+    public static function delta($field = 'severity', $to = null, $from = null, $milestone = null) {
         $openLastWeek = 'COUNT(CASE'
             . ' WHEN (CDL.dateCreated < CAST("%1$s" AS DATE)'
             . ' && (status = "1" || dateClosed > CAST("%1$s" AS DATE))) THEN defID'
@@ -40,6 +41,8 @@ class Report {
                 'groupBy' => 'groupToResolve'
             ]
         ];
+
+        $headings = [ $field, $to, $from, $milestone ];
         
         $fields = [
             $params[$field]['select'],
@@ -56,11 +59,12 @@ class Report {
         if (!empty($milestone))
             $where[] = [ 'requiredBy', $milestone, '<='];
         
-        return new Report('CDL', $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
+        return new Report('CDL', $headings, $fields, $params[$field]['join'], $where, $params[$field]['groupBy']);
     }    
     
-    private function __construct($table = null, $fields = [], $join = null, $where = null, $groupBy = null) {
+    private function __construct($table = null, $headings = [], $fields = [], $join = null, $where = null, $groupBy = null) {
         $this->table = $table;
+        $this->headings = $headings;
         $this->fields = $fields;
 
         if (!empty($join)) {
@@ -106,8 +110,14 @@ class Report {
     }
 
     public function get() {
-        error_log('query..........> ' . $this->getQuery());
         return $this->data;
+    }
+
+    public function getWithHeadings() {
+        $dataWithHeadings = $this->data;
+        $headings = array_filter($this->headings);
+        array_unshift($dataWithHeadings, $headings);
+        return $dataWithHeadings;
     }
 
     public function __toString() {

--- a/src/Report.php
+++ b/src/Report.php
@@ -103,6 +103,7 @@ class Report {
     }
 
     public function get() {
+        error_log('query..........> ' . $this->getQuery());
         return $this->data;
     }
 

--- a/templates/dashboard.html.twig
+++ b/templates/dashboard.html.twig
@@ -121,7 +121,7 @@
     drawSeverityChart(window.d3, {{ data.totalBlocker }}, {{ data.totalCrit }}, {{ data.totalMajor }}, {{ data.totalMinor }})
 
     function downloadReport() {
-        fetch('/api/report.php?milestone=sit3&format=csv&type=delta', {
+        fetch('/api/report.php?field={{- data.selected.field -}}&milestone={{- data.selected.milestone -}}&to={{- data.selected.to -}}&from={{- data.selected.from -}}&format=csv&type=delta', {
             credentials: 'same-origin'
         }).then(res => {
             if (!res.ok) throw res

--- a/templates/dashboard.html.twig
+++ b/templates/dashboard.html.twig
@@ -68,15 +68,13 @@
             <div class='card-body grey-bg'>
                 <ul class='dash__list'>
                     <li class='bg-secondary text-white text-center row dash__list-row'>
-                        <h5 class='col-sm-5 col-8 dash__list-heading'>System</h5>
-                        <h5 class='col-sm-3 col-4 dash__list-heading text-right'>Actions</h5>
-                        <h5 class='col-sm-4 dash__list-heading dash__list-col-lead'>Lead</h5>
+                        <h5 class='col-6 dash__list-heading'>System</h5>
+                        <h5 class='col-6 dash__list-heading'>Actions</h5>
                     </li>
                     {% for system in data.system %}
                     <li class='row thin-grey-separator text-center dash__list-row'>
-                        <span class='col-sm-5 col-8'>{{ system.systemName }}</span>
-                        <span class='col-sm-3 col-4 text-right'>{{ system.count }}</span>
-                        <span class='col-sm-4 dash__list-col-lead'>{{ system.lead }}</span>
+                        <span class='col-6'>{{ system.systemName }}</span>
+                        <span class='col-6'>{{ system.count }}</span>
                     </li>
                     {% endfor %}
                 </ul>

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -1,8 +1,15 @@
 {# 'data' => [
+##      'selected' => [
+##          'field' => <fieldName>,
+##          'from' => <fromDate>,
+##          'to' => <toDate>,
+##          ['required by' => <milestone>]
+##      ],
 ##      [
-##          'system' => (string),
-##          'openLastWeek' => (int),
-##          'openThisWeek' => (int),
+##          'fieldName' => (string),
+##          'fromDate' => (int),
+##          'toDate' => (int),
+##          ['required by' => (int)]
 ##      ]
 ##  ]
 #}
@@ -49,6 +56,9 @@
                 <div class="col-sm-3 text-right">Open on {{ data.selected.to }}</div>
                 <div class="col-sm-3 text-right">{{ deltaLabel }}</div>
             </div>
+            {% if data.deltaReport.error %}
+            <h4 class="text-red text-center pt-3 pb-3">{{ data.deltaReport.error }}</h4>
+            {% else %}
             {% for row in data.deltaReport %}
             <div class="row thin-grey-separator ml-0 mr-0">
                 <div class="col-sm-3">
@@ -65,6 +75,7 @@
                 </div>
             </div>
             {% endfor %}
+            {% endif %}
         </div>
     </div>
 </div>

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -7,27 +7,30 @@
 ##  ]
 #}
 
-{% set thisWeekLabel = "Open this week: " %}
-{% set lastWeekLabel = "Open last week: " %}
-{% set deltaLabel = "Delta this week: " %}
+{% set thisWeekLabel = data.selected.to %}
+{% set lastWeekLabel = data.selected.from %}
+{% set deltaLabel = "Delta" %}
 <div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
         <form id="delta-picker" method="GET" action="#deltaReport">
             <label for="field">Open Deficiencies by</label>
             <select id="field" name="field">
                 <option></option>
-                <option value="severity">Severity</option>
-                <option value="system">System Affected</option>
+                {% for field in ['severity', 'system'] %}
+                {% set selected = data.selected.field == field ? ' selected' : '' %}
+                <option value="{{ field }}"{{ selected }}>{{ field | capitalize }}</option>
+                {% endfor %}
             </select>
             <label for="from-date">From</label>
-            <input id="from-date" name="from" type="date">
+            <input id="from-date" name="from" type="date" value="{{ data.selected.from }}">
             <label for="to-date">To</label>
-            <input id="to-date" name="to" type="date">
+            <input id="to-date" name="to" type="date" value="{{ data.selected.to }}">
             <label for="milestone">Required prior to</label>
             <select id="milestone" name="milestone">
                 <option></option>
                 {% for milestone in data.milestones %}
-                <option value="{{ milestone.id }}">{{ milestone.name }}</option>
+                {% set selected = data.selected.milestone == milestone ? ' selected' : '' %}
+                <option value="{{ milestone.id }}"{{ selected }}>{{ milestone.name }}</option>
                 {% endfor %}
             </select>
             <button type="submit" class="btn btn-primary">Apply</button>
@@ -42,7 +45,7 @@
                 <button id='downloadReport' type='button' onclick='return downloadReport()' class="btn btn-sm btn-success">Download this data</button>
             </header>
             <div class="row thick-black-line ml-0 mr-0 mb-1 weekly-report__list-heading">
-                <div class="col-sm-3">System</div>
+                <div class="col-sm-3">{{ data.selected.field | capitalize }}</div>
                 <div class="col-sm-3 text-right">{{ lastWeekLabel }}</div>
                 <div class="col-sm-3 text-right">{{ thisWeekLabel }}</div>
                 <div class="col-sm-3 text-right">{{ deltaLabel }}</div>

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -7,8 +7,8 @@
 ##  ]
 #}
 
-{% set thisWeekLabel = data.selected.to %}
-{% set lastWeekLabel = data.selected.from %}
+{% set toLabel = data.selected.to %}
+{% set fromLabel = data.selected.from %}
 {% set deltaLabel = "Delta" %}
 <div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
@@ -37,9 +37,9 @@
         </form>
         <div class="thin-grey-border border-radius">
             <header class="d-flex justify-content-between pad grey-bg item-margin-bottom">
-                <span>Deficiencies by {{ data.selected.field | default('_') }}
-                from {{ data.selected.from | default('_') }}
-                to {{ data.selected.to | default('_') }}
+                <span>Deficiencies by {{ data.selected.field | default('__') }}
+                from {{ data.selected.from | default('__') }}
+                to {{ data.selected.to | default('__') }}
                 {% if data.selected.milestone %}required prior to {{ data.selected.milestone }}{% endif %}
                 </span>
                 <button id='downloadReport' type='button' onclick='return downloadReport()' class="btn btn-sm btn-success">Download this data</button>
@@ -53,16 +53,16 @@
             {% for row in data.deltaReport %}
             <div class="row thin-grey-separator ml-0 mr-0">
                 <div class="col-sm-3">
-                    <div class="weekly-report__system-name">{{ row.system }}</div>
+                    <div class="weekly-report__system-name">{{ row.fieldName }}</div>
                 </div>
                 <div class="col-sm-3 text-right">
-                    <div><span class="weekly-report__label">{{ lastWeekLabel }}</span>{{ row.openLastWeek }}</div>
+                    <div><span class="weekly-report__label">{{ fromLabel }}</span>{{ row.fromDate }}</div>
                 </div>
                 <div class="col-sm-3 text-right">
-                    <div><span class="weekly-report__label">{{ thisWeekLabel }}</span>{{ row.openThisWeek }}</div>
+                    <div><span class="weekly-report__label">{{ toLabel }}</span>{{ row.toDate }}</div>
                 </div>
                 <div class="col-sm-3 text-right">
-                    <div><span class="weekly-report__label">{{ deltaLabel }}</span>{{ row.openLastWeek - row.openThisWeek }}</div>
+                    <div><span class="weekly-report__label">{{ deltaLabel }}</span>{{ row.fromDate - row.toDate }}</div>
                 </div>
             </div>
             {% endfor %}

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -13,29 +13,32 @@
 <div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
         <form id="delta-picker" method="GET" action="#deltaReport">
-            <label for="field">Show</label>
+            <label for="field">Open Deficiencies by</label>
             <select id="field" name="field">
                 <option></option>
                 <option value="severity">Severity</option>
                 <option value="system">System Affected</option>
             </select>
-            <span> Open Deficiencies</span>
             <label for="from-date">From</label>
             <input id="from-date" name="from" type="date">
             <label for="to-date">To</label>
             <input id="to-date" name="to" type="date">
-            <label for="milestone">By</label>
+            <label for="milestone">Required prior to</label>
             <select id="milestone" name="milestone">
                 <option></option>
                 {% for milestone in data.milestones %}
                 <option value="{{ milestone.id }}">{{ milestone.name }}</option>
                 {% endfor %}
             </select>
-            <button type="submit">Apply</button>
+            <button type="submit" class="btn btn-primary">Apply</button>
         </form>
         <div class="thin-grey-border border-radius">
             <header class="d-flex justify-content-between pad grey-bg item-margin-bottom">
-                <span>Weekly delta of open Deficiencies that are required for closure prior to Phase 3 start</span>
+                <span>Deficiencies by {{ data.selected.field | default('_') }}
+                from {{ data.selected.from | default('_') }}
+                to {{ data.selected.to | default('_') }}
+                {% if data.selected.milestone %}required prior to {{ data.selected.milestone }}{% endif %}
+                </span>
                 <button id='downloadReport' type='button' onclick='return downloadReport()' class="btn btn-sm btn-success">Download this data</button>
             </header>
             <div class="row thick-black-line ml-0 mr-0 mb-1 weekly-report__list-heading">

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -10,8 +10,28 @@
 {% set thisWeekLabel = "Open this week: " %}
 {% set lastWeekLabel = "Open last week: " %}
 {% set deltaLabel = "Delta this week: " %}
-<div id="weeklyReport" class="row item-margin-bottom">
+<div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
+        <form id="delta-picker" method="GET" action="#deltaReport">
+            <label for="group-by">Show</label>
+            <select id="group-by">
+                <option></option>
+                <option value="severity">Severity</option>
+                <option value="systemAffected">System Affected</option>
+            </select>
+            <span> Open Deficiencies</span>
+            <label for="from-date">From</label>
+            <input id="from-date" type="date">
+            <label for="to-date">To</label>
+            <input id="to-date" type="date">
+            <label for="milestone">By</label>
+            <select id="milestone">
+                {% for milestone in data.milestones %}
+                <option value="{{ milestone.id }}">{{ milestone.name }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit">Apply</button>
+        </form>
         <div class="thin-grey-border border-radius">
             <header class="d-flex justify-content-between pad grey-bg item-margin-bottom">
                 <span>Weekly delta of open Deficiencies that are required for closure prior to Phase 3 start</span>
@@ -23,7 +43,7 @@
                 <div class="col-sm-3 text-right">{{ thisWeekLabel }}</div>
                 <div class="col-sm-3 text-right">{{ deltaLabel }}</div>
             </div>
-            {% for row in data.weeklyReport %}
+            {% for row in data.deltaReport %}
             <div class="row thin-grey-separator ml-0 mr-0">
                 <div class="col-sm-3">
                     <div class="weekly-report__system-name">{{ row.system }}</div>

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -12,10 +12,9 @@
 {% set deltaLabel = "Delta" %}
 <div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
-        <form id="delta-picker" method="GET" action="#deltaReport">
+        <form id="delta-picker" method="GET" action="#deltaReport" class="item-margin-bottom">
             <label for="field">Open Deficiencies by</label>
             <select id="field" name="field">
-                <option></option>
                 {% for field in ['severity', 'system'] %}
                 {% set selected = data.selected.field == field ? ' selected' : '' %}
                 <option value="{{ field }}"{{ selected }}>{{ field | capitalize }}</option>
@@ -29,7 +28,7 @@
             <select id="milestone" name="milestone">
                 <option></option>
                 {% for milestone in data.milestones %}
-                {% set selected = data.selected.milestone == milestone ? ' selected' : '' %}
+                {% set selected = data.selected.milestone == milestone.id ? ' selected' : '' %}
                 <option value="{{ milestone.id }}"{{ selected }}>{{ milestone.name }}</option>
                 {% endfor %}
             </select>
@@ -46,8 +45,8 @@
             </header>
             <div class="row thick-black-line ml-0 mr-0 mb-1 weekly-report__list-heading">
                 <div class="col-sm-3">{{ data.selected.field | capitalize }}</div>
-                <div class="col-sm-3 text-right">{{ data.selected.from }}</div>
-                <div class="col-sm-3 text-right">{{ data.selected.to }}</div>
+                <div class="col-sm-3 text-right">Open on {{ data.selected.from }}</div>
+                <div class="col-sm-3 text-right">Open on {{ data.selected.to }}</div>
                 <div class="col-sm-3 text-right">{{ deltaLabel }}</div>
             </div>
             {% for row in data.deltaReport %}

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -46,8 +46,8 @@
             </header>
             <div class="row thick-black-line ml-0 mr-0 mb-1 weekly-report__list-heading">
                 <div class="col-sm-3">{{ data.selected.field | capitalize }}</div>
-                <div class="col-sm-3 text-right">{{ lastWeekLabel }}</div>
-                <div class="col-sm-3 text-right">{{ thisWeekLabel }}</div>
+                <div class="col-sm-3 text-right">{{ data.selected.from }}</div>
+                <div class="col-sm-3 text-right">{{ data.selected.to }}</div>
                 <div class="col-sm-3 text-right">{{ deltaLabel }}</div>
             </div>
             {% for row in data.deltaReport %}

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -34,9 +34,9 @@
             <label for="milestone">Required prior to</label>
             <select id="milestone" name="milestone">
                 <option></option>
-                {% for milestone in data.milestones %}
-                {% set selected = data.selected.milestone == milestone.id ? ' selected' : '' %}
-                <option value="{{ milestone.id }}"{{ selected }}>{{ milestone.name }}</option>
+                {% for id, milestone in data.milestones %}
+                {% set selected = data.selected.milestone == id ? ' selected' : '' %}
+                <option value="{{ id }}"{{ selected }}>{{ milestone }}</option>
                 {% endfor %}
             </select>
             <button type="submit" class="btn btn-primary">Apply</button>
@@ -46,7 +46,7 @@
                 <span>Deficiencies by {{ data.selected.field | default('__') }}
                 from {{ data.selected.from | default('__') }}
                 to {{ data.selected.to | default('__') }}
-                {% if data.selected.milestone %}required prior to {{ data.selected.milestone }}{% endif %}
+                {% if data.selected.milestone %}required prior to {{ data.milestones[data.selected.milestone] }}{% endif %}
                 </span>
                 <button id='downloadReport' type='button' onclick='return downloadReport()' class="btn btn-sm btn-success">Download this data</button>
             </header>

--- a/templates/weekly-report.html.twig
+++ b/templates/weekly-report.html.twig
@@ -13,19 +13,20 @@
 <div id="deltaReport" class="row item-margin-bottom">
     <div class="col-sm-10 offset-sm-1">
         <form id="delta-picker" method="GET" action="#deltaReport">
-            <label for="group-by">Show</label>
-            <select id="group-by">
+            <label for="field">Show</label>
+            <select id="field" name="field">
                 <option></option>
                 <option value="severity">Severity</option>
-                <option value="systemAffected">System Affected</option>
+                <option value="system">System Affected</option>
             </select>
             <span> Open Deficiencies</span>
             <label for="from-date">From</label>
-            <input id="from-date" type="date">
+            <input id="from-date" name="from" type="date">
             <label for="to-date">To</label>
-            <input id="to-date" type="date">
+            <input id="to-date" name="to" type="date">
             <label for="milestone">By</label>
-            <select id="milestone">
+            <select id="milestone" name="milestone">
+                <option></option>
                 {% for milestone in data.milestones %}
                 <option value="{{ milestone.id }}">{{ milestone.name }}</option>
                 {% endfor %}

--- a/tests/BARTDeficiencyTest.php
+++ b/tests/BARTDeficiencyTest.php
@@ -38,7 +38,7 @@ final class BARTDeficiencyTest extends TestCase
             'resolution_vta' => 'test resolution vta',
             'priority_vta' => 1,
             'safety_cert_vta' => 1,
-            'created_by' => 32
+            'created_by' => 1
         ]))->insert();
 
         $this->assertNotEquals(intval($this->newDefID), 0);
@@ -59,7 +59,7 @@ final class BARTDeficiencyTest extends TestCase
             'resolution_vta' => 'test resolution vta',
             'priority_vta' => 1,
             'safety_cert_vta' => 1,
-            'created_by' => 32,
+            'created_by' => 1,
             'repo' => 1,
             'evidenceID' => 'test-evidence_ID',
             'evidenceType' => 1
@@ -87,7 +87,7 @@ final class BARTDeficiencyTest extends TestCase
             'resolution_vta' => 'test resolution vta',
             'priority_vta' => 1,
             'safety_cert_vta' => 1,
-            'created_by' => 32,
+            'created_by' => 1,
             'repo' => 1,
             'evidenceID' => 'test-evidence_ID',
             'evidenceType' => 1

--- a/tests/DeficiencyTest.php
+++ b/tests/DeficiencyTest.php
@@ -52,7 +52,7 @@ final class DeficiencyTest extends TestCase
             'identifiedBy' => 'ckb',
             'defType' => 1,
             'description' => 'test_description',
-            'created_by' => 'demo', // required creation info
+            'created_by' => 'test_user', // required creation info
         ]))->insert();
         
         $this->assertNotEquals(intval($this->newDefID), 0);
@@ -85,7 +85,7 @@ final class DeficiencyTest extends TestCase
             'identifiedBy' => 'ckb',
             'defType' => 1,
             'description' => 'test_description',
-            'created_by' => 'demo', // required creation info
+            'created_by' => 'test_user', // required creation info
             'repo' => 1, // required closure info, fk
             'evidenceType' => 1, // required closure info, fk
             'evidenceID' => 'aaa000-bbb999' // required closure info
@@ -116,7 +116,7 @@ final class DeficiencyTest extends TestCase
             'identifiedBy' => 'ckb',
             'defType' => 1,
             'description' => 'test_description',
-            'created_by' => 'demo', // required creation info
+            'created_by' => 'test_user', // required creation info
         ]))->insert();
 
         $newDef = new Deficiency($this->newDefID);

--- a/tests/DeficiencyTest.php
+++ b/tests/DeficiencyTest.php
@@ -14,6 +14,24 @@ final class DeficiencyTest extends TestCase
         $this->newDefID = null;
     }
 
+    protected function tearDown(): void
+    {
+        try {
+            $db = new MysqliDb(DB_CREDENTIALS);
+
+            $db->where('defID', $this->newDefID);
+            $db->delete('CDL');
+        } catch (Exception $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } catch (Error $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } finally {
+            if (!empty($link) && is_a($link, 'MysqliDb')) $db->disconnect();
+        }
+    }
+
     public function testCanCreateNewWithRequiredProps(): void
     {
         $this->assertInstanceOf(

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -8,7 +8,73 @@ use PHPUnit\Framework\TestCase;
 final class ReportTest extends TestCase
 {
     protected static $dateFormat = 'Y-m-d';
-    public static $fixtureIDs = [];
+    private static $fixtureIDs = [];
+    private static $fixtureData = [
+        [
+            'dateCreated' => '2019-01-01',
+            'status' => 1,
+            'severity' => 3,
+            'groupToResolve' => 1
+        ],
+        [
+            'dateCreated' => '2019-01-01',
+            'status' => 2,
+            'severity' => 3,
+            'groupToResolve' => 1,
+            'dateClosed' => '2019-03-31',
+            'repo' => 1,
+            'evidenceID' => 'test_evidenceID',
+            'evidenceType' => 1
+        ],
+        [
+            'dateCreated' => '2019-03-01',
+            'status' => 1,
+            'severity' => 2,
+            'groupToResolve' => 2
+        ],
+        [
+            'dateCreated' => '2019-03-01',
+            'status' => 2,
+            'severity' => 2,
+            'groupToResolve' => 2,
+            'dateClosed' => '2019-05-31',
+            'repo' => 1,
+            'evidenceID' => 'test_evidenceID',
+            'evidenceType' => 1
+        ],
+        [
+            'dateCreated' => '2019-05-01',
+            'status' => 1,
+            'severity' => 1,
+            'groupToResolve' => 3
+        ],
+        [
+            'dateCreated' => '2019-05-01',
+            'status' => 2,
+            'severity' => 1,
+            'groupToResolve' => 3,
+            'dateClosed' => '2019-07-31',
+            'repo' => 1,
+            'evidenceID' => 'test_evidenceID',
+            'evidenceType' => 1
+        ],
+        [
+            'dateCreated' => '2019-07-01',
+            'status' => 1,
+            'severity' => 4,
+            'groupToResolve' => 4
+        ],
+        [
+            'dateCreated' => '2019-07-01',
+            'status' => 2,
+            'severity' => 4,
+            'groupToResolve' => 4,
+            'dateClosed' => '2019-07-31',
+            'repo' => 1,
+            'evidenceID' => 'test_evidenceID',
+            'evidenceType' => 1
+        ],
+    ];
 
     public static function setUpBeforeClass(): void
     {
@@ -17,25 +83,24 @@ final class ReportTest extends TestCase
         try {
             $db = new MysqliDb(DB_CREDENTIALS);
 
-            $def = new Deficiency(null, [
-                'safetyCert' => 1,
-                'systemAffected' => 1,
-                'location' => 1,
-                'specLoc' => 'test_specLoc',
-                'status' => 1,
-                'severity' => 3,
-                'dueDate' => date(self::$dateFormat),
-                'groupToResolve' => 1,
-                'requiredBy' => 1,
-                'contractID' => 1,
-                'identifiedBy' => 'ckb',
-                'defType' => 1,
-                'description' => 'test_description',
-                'dateCreated' => (DateTime::createFromFormat(self::$dateFormat, '2019-01-01'))->format(self::$dateFormat),
-                'created_by' => 'test_user'
-            ]);
+            foreach (self::$fixtureData as $defData) {
+                $def = new Deficiency(null, [
+                    'safetyCert' => 1,
+                    'systemAffected' => 1,
+                    'location' => 1,
+                    'specLoc' => 'test_specLoc',
+                    'dueDate' => date(self::$dateFormat),
+                    'requiredBy' => 1,
+                    'contractID' => 1,
+                    'identifiedBy' => 'ckb',
+                    'defType' => 1,
+                    'description' => 'test_description',
+                    'created_by' => 'test_user'
+                ] + $defData);
+
+                array_push(self::$fixtureIDs, $def->insert());
+            }
     
-            array_push(self::$fixtureIDs, $def->insert());
         } catch (Exception $e) {
             error_log(print_r($e, true));
             throw $e;
@@ -74,10 +139,36 @@ final class ReportTest extends TestCase
         $this->assertInstanceOf(Report::class, $report);
 
         $reportData = $report->getWithHeadings();
+        
+        $endDate = date(static::$dateFormat);
+        $startDate = DateTime
+        ::createFromFormat(static::$dateFormat, $endDate)
+        ->sub(new DateInterval('P7D'));
+        $expected = [
+            'severity', $startDate->format(static::$dateFormat) , $endDate
+        ];
+        $headings = array_shift($reportData);
 
-        $this->assertEquals($reportData[0][0], 'severity');
+        $this->assertSame($headings, $expected);
 
-        fwrite(STDOUT, print_r($report->getQuery(), true));
-        fwrite(STDOUT, print_r($reportData, true));
+        $severityOrder = ['Minor', 'Major', 'Critical', 'Blocker'];
+        $this->assertTrue(usort($reportData, function($a, $b) use ($severityOrder) {
+            $aIndex = array_search($a['fieldName'], $severityOrder);
+            $bIndex = array_search($b['fieldName'], $severityOrder);
+            if ($aIndex === false)
+                throw new UnexpectedValueException("Unexpected value {$a['fieldName']} found in \$reportData");
+            if ($bIndex === false)
+                throw new UnexpectedValueException("Unexpected value {$a['fieldName']} found in \$reportData");
+            return $aIndex - $bIndex;
+        }));
+
+        $this->assertSame($reportData, [
+            [ 'fieldName' => 'Minor', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Blocker', 'fromDate' => 1, 'toDate' => 1 ],
+        ]);
+
+        // fwrite(STDOUT, print_r($report->getQuery(), true));
     }
 }

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -225,15 +225,15 @@ final class ReportTest extends TestCase
         ::createFromFormat(static::$dateFormat, $endDateStr)
         ->sub(new DateInterval('P7D'))
         ->format(static::$dateFormat);
-        $expect = [ 'severity', $startDateStr, $endDateStr, $milestone ];
+        $expect = [ 'severity', $startDateStr, $endDateStr, 'required by' ];
 
         $this->assertSame($expect, $headings);
 
         $this->assertTrue($this->sortByArrayOrder($report, static::$severityOrder));
 
         $expected = [
-            [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
-            [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
+            [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
         ];
         $this->assertSame($expected, $report);
     }
@@ -297,29 +297,31 @@ final class ReportTest extends TestCase
 
     public function testDefaultSystemReportWithMilestoneReturnsExpectedData(): void
     {
-        $report = Report::delta('system', null, null, 5)->get();
+        $milestone = 5;
+        $report = Report::delta('system', null, null, $milestone)->get();
 
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
-            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1 ],
-            [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1 ]
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ]
         ];
 
         $this->assertSame($expect, $report);
     }
 
-    public function testSystemReportWithEarlierDateRangeWithMilestoneReturnsExpectedData(): void
+    public function testSystemReportWithEarlierDateRangeAndMilestoneReturnsExpectedData(): void
     {
         $startDateStr = '2019-04-01';
         $endDateStr = '2019-06-01';
+        $milestone = 5;
 
-        $report = Report::delta('system', $startDateStr, $endDateStr, 5)->get();
+        $report = Report::delta('system', $startDateStr, $endDateStr, $milestone)->get();
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
-            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1 ],
-            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1, 'required by' => $milestone ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2, 'required by' => $milestone ],
         ];
 
         $this->assertSame($expect, $report);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -160,37 +160,36 @@ final class ReportTest extends TestCase
 
         $this->assertSame($headings, $expected);
 
-        $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
+        $this->assertTrue($this->sortByArrayOrder($reportData, static::$severityOrder));
 
-        $this->assertSame([
+        $expected = [
             [ 'fieldName' => 'Minor', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Blocker', 'fromDate' => 1, 'toDate' => 1 ],
-        ], $reportData);
+        ];
+        $this->assertSame($expected, $reportData);
     }
 
     public function testSeverityReportWithEarlierStartDateContainsExpectedData(): void
     {
         $startDateStr = '2019-07-01';
 
-        $report = Report::delta('severity', $startDateStr);
-        $this->assertInstanceOf(Report::class, $report);
+        $report = Report::delta('severity', $startDateStr)->getWithHeadings();
 
-        $reportData = $report->getWithHeadings();
-
-        $headings = array_shift($reportData);
+        $headings = array_shift($report);
         $expected = [ 'severity', $startDateStr, date('Y-m-d')];
         $this->assertSame($expected, $headings);
 
-        $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
+        $this->assertTrue($this->sortByArrayOrder($report, static::$severityOrder));
 
-        $this->assertSame([
+        $expected = [
             [ 'fieldName' => 'Minor', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Critical', 'fromDate' => 2, 'toDate' => 1 ],
             [ 'fieldName' => 'Blocker', 'fromDate' => 2, 'toDate' => 1 ],
-        ], $reportData);
+        ];
+        $this->assertSame($expected, $report);
     }
 
     public function testSeverityReportWithEarlierStartAndEndDatesContainsExpectedData(): void
@@ -198,33 +197,29 @@ final class ReportTest extends TestCase
         $startDateStr = '2019-05-01';
         $endDateStr = '2019-07-01';
 
-        $report = Report::delta('severity', $startDateStr, $endDateStr);
-        $this->assertInstanceOf(Report::class, $report);
+        $report = Report::delta('severity', $startDateStr, $endDateStr)->getWithHeadings();
 
-        $reportData = $report->getWithHeadings();
-
-        $headings = array_shift($reportData);
+        $headings = array_shift($report);
         $expected = [ 'severity', $startDateStr, $endDateStr ];
         $this->assertSame($expected, $headings);
 
-        $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
+        $this->assertTrue($this->sortByArrayOrder($report, static::$severityOrder));
 
-        $this->assertSame([
+        $expected = [
             [ 'fieldName' => 'Minor', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Major', 'fromDate' => 2, 'toDate' => 1 ],
             [ 'fieldName' => 'Critical', 'fromDate' => 2, 'toDate' => 2 ],
             [ 'fieldName' => 'Blocker', 'fromDate' => 0, 'toDate' => 2 ],
-        ], $reportData);
+        ];
+        $this->assertSame($expected, $report);
     }
 
     public function testDefaultSeverityReportDatesWithMilestoneContainsExpectedData(): void
     {
         $milestone = 4;
-        $report = Report::delta('severity', null, null, $milestone);
+        $report = Report::delta('severity', null, null, $milestone)->getWithHeadings();
 
-        $reportData = $report->getWithHeadings();
-
-        $headings = array_shift($reportData);
+        $headings = array_shift($report);
         $endDateStr = date('Y-m-d');
         $startDateStr = DateTime
         ::createFromFormat(static::$dateFormat, $endDateStr)
@@ -234,30 +229,29 @@ final class ReportTest extends TestCase
 
         $this->assertSame($expect, $headings);
 
-        $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
+        $this->assertTrue($this->sortByArrayOrder($report, static::$severityOrder));
 
-        $this->assertSame([
+        $expected = [
             [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1 ],
-        ], $reportData);
+        ];
+        $this->assertSame($expected, $report);
     }
 
     public function testSystemReportWithDefaultDatesReturnsExpectedData(): void
     {
-        $report = Report::delta('system');
+        $report = Report::delta('system')->getWithHeadings();
         $endDateStr = date('Y-m-d');
         $startDateStr = DateTime
         ::createFromFormat(static::$dateFormat, $endDateStr)
         ->sub(new DateInterval('P7D'))
         ->format(static::$dateFormat);
 
-        $reportData = $report->getWithHeadings();
-
-        $headings = array_shift($reportData);
+        $headings = array_shift($report);
         $expect = [ 'system', $startDateStr, $endDateStr ];
         $this->assertSame($expect, $headings);
 
-        $this->assertTrue($this->sortByArrayOrder($reportData, static::$systemOrder));
+        $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
             [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
@@ -265,12 +259,11 @@ final class ReportTest extends TestCase
             [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Fire Protection', 'fromDate' => 1, 'toDate' => 1 ]
         ];
-        $this->assertSame($expect, $reportData);
+        $this->assertSame($expect, $report);
     }
 
     public function testSystemReportWithEarlierStartDateReturnsExpectedData(): void
     {
-        // $endDateStr = date('Y-m-d');
         $startDateStr = '2019-06-30';
 
         $report = Report::delta('system', $startDateStr)->get();
@@ -297,8 +290,6 @@ final class ReportTest extends TestCase
         $expect = [
             [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 2 ],
-            // [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
-            // [ 'fieldName' => 'Fire Protection', 'fromDate' => 0, 'toDate' => 2 ]
         ];
 
         $this->assertSame($expect, $report);
@@ -306,9 +297,8 @@ final class ReportTest extends TestCase
 
     public function testDefaultSystemReportWithMilestoneReturnsExpectedData(): void
     {
-        $report = Report::delta('system', null, null, 5);
-        $report = $report->getWithHeadings();
-        array_shift($report);
+        $report = Report::delta('system', null, null, 5)->get();
+
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
@@ -333,17 +323,6 @@ final class ReportTest extends TestCase
         ];
 
         $this->assertSame($expect, $report);
-    }
-
-    private function sortBySeverityName($a, $b) {
-        $aIndex = array_search($a['fieldName'], static::$severityOrder);
-        $bIndex = array_search($b['fieldName'], static::$severityOrder);
-        if ($aIndex === false || $bIndex === false)
-            throw new UnexpectedValueException(sprintf(
-                'Unexpected value %s found in $reportData',
-                $aIndex === false ? $a['fieldName'] : $b['fieldName']
-            ));
-        return $aIndex - $bIndex;
     }
 
     private function sortByArrayOrder(&$target, $order) {

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -221,6 +221,7 @@ final class ReportTest extends TestCase
     {
         $milestone = 4;
         $report = Report::delta('severity', null, null, $milestone);
+        fwrite(STDOUT, $report->getQuery());
 
         $reportData = $report->getWithHeadings();
 
@@ -258,7 +259,6 @@ final class ReportTest extends TestCase
         $this->assertSame($expect, $headings);
 
         $this->assertTrue($this->sortByArrayOrder($reportData, static::$systemOrder));
-        fwrite(STDOUT, print_r($reportData, true));
 
         $expect = [
             [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
@@ -267,6 +267,73 @@ final class ReportTest extends TestCase
             [ 'fieldName' => 'Fire Protection', 'fromDate' => 1, 'toDate' => 1 ]
         ];
         $this->assertSame($expect, $reportData);
+    }
+
+    public function testSystemReportWithEarlierStartDateReturnsExpectedData(): void
+    {
+        // $endDateStr = date('Y-m-d');
+        $startDateStr = '2019-06-30';
+
+        $report = Report::delta('system', $startDateStr)->get();
+        $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
+
+        $expect = [
+            [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 2, 'toDate' => 1 ],
+            [ 'fieldName' => 'Fire Protection', 'fromDate' => 0, 'toDate' => 1 ]
+        ];
+
+        $this->assertSame($expect, $report);
+    }
+
+    public function testSystemReportWithEarlierStartAndEndDateReturnsExpectedData(): void
+    {
+        $startDateStr = '2019-04-30';
+        $endDateStr = '2019-07-10';
+
+        $report = Report::delta('system', $startDateStr, $endDateStr)->get();
+        $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
+
+        $expect = [
+            [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1 ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
+            [ 'fieldName' => 'Fire Protection', 'fromDate' => 0, 'toDate' => 2 ]
+        ];
+
+        $this->assertSame($expect, $report);
+    }
+
+    public function testDefaultSystemReportWithMilestoneReturnsExpectedData(): void
+    {
+        $report = Report::delta('system', null, null, 5);
+        fwrite(STDOUT, $report->getQuery());
+        $report = $report->get();
+        $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
+
+        $expect = [
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1 ]
+        ];
+
+        $this->assertSame($expect, $report);
+    }
+
+    public function testSystemReportWithEarlierDateRangeWithMilestoneReturnsExpectedData(): void
+    {
+        $startDateStr = '2019-04-01';
+        $endDateStr = '2019-06-01';
+
+        $report = Report::delta('system', $startDateStr, $endDateStr, 5)->get();
+        $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
+
+        $expect = [
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1 ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
+        ];
+
+        $this->assertSame($expect, $report);
     }
 
     private function sortBySeverityName($a, $b) {

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+use SVBX\Deficiency;
+use SVBX\Report;
+use PHPUnit\Framework\TestCase;
+
+final class ReportTest extends TestCase
+{
+    protected static $dateFormat = 'Y-m-d';
+    public static $fixtureIDs = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$fixtureIDs = [];
+
+        try {
+            $db = new MysqliDb(DB_CREDENTIALS);
+
+            $def = new Deficiency(null, [
+                'safetyCert' => 1,
+                'systemAffected' => 1,
+                'location' => 1,
+                'specLoc' => 'test_specLoc',
+                'status' => 1,
+                'severity' => 3,
+                'dueDate' => date(self::$dateFormat),
+                'groupToResolve' => 1,
+                'requiredBy' => 1,
+                'contractID' => 1,
+                'identifiedBy' => 'ckb',
+                'defType' => 1,
+                'description' => 'test_description',
+                'dateCreated' => (DateTime::createFromFormat(self::$dateFormat, '2019-01-01'))->format(self::$dateFormat),
+                'created_by' => 'test_user'
+            ]);
+    
+            array_push(self::$fixtureIDs, $def->insert());
+        } catch (Exception $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } catch (Error $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } finally {
+            if (!empty($db) && is_a($db, 'MysqliDb')) $db->disconnect();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        try {
+            $db = new MysqliDb(DB_CREDENTIALS);
+    
+            foreach (self::$fixtureIDs as $id) {
+                $db->where('defID', $id);
+                $db->delete('CDL');
+            }
+        } catch (Exception $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } catch (Error $e) {
+            error_log(print_r($e, true));
+            throw $e;
+        } finally {
+            if (!empty($db) && is_a($db, 'MysqliDb')) $db->disconnect();
+            self::$fixtureIDs = [];
+        }
+    }
+
+    public function testInstantiateReport(): void
+    {
+        $report = Report::delta();
+        $this->assertInstanceOf(Report::class, $report);
+
+        $reportData = $report->getWithHeadings();
+
+        $this->assertEquals($reportData[0][0], 'severity');
+
+        fwrite(STDOUT, print_r($report->getQuery(), true));
+        fwrite(STDOUT, print_r($reportData, true));
+    }
+}

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -289,17 +289,17 @@ final class ReportTest extends TestCase
 
     public function testSystemReportWithEarlierStartAndEndDateReturnsExpectedData(): void
     {
-        $startDateStr = '2019-04-30';
-        $endDateStr = '2019-07-10';
+        $startDateStr = '2019-04-01';
+        $endDateStr = '2019-04-30';
 
         $report = Report::delta('system', $startDateStr, $endDateStr)->get();
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
             [ 'fieldName' => 'Electrical', 'fromDate' => 1, 'toDate' => 1 ],
-            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1 ],
-            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
-            [ 'fieldName' => 'Fire Protection', 'fromDate' => 0, 'toDate' => 2 ]
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 2 ],
+            // [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2 ],
+            // [ 'fieldName' => 'Fire Protection', 'fromDate' => 0, 'toDate' => 2 ]
         ];
 
         $this->assertSame($expect, $report);
@@ -309,7 +309,8 @@ final class ReportTest extends TestCase
     {
         $report = Report::delta('system', null, null, 5);
         fwrite(STDOUT, $report->getQuery());
-        $report = $report->get();
+        $report = $report->getWithHeadings();
+        array_shift($report);
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -225,15 +225,15 @@ final class ReportTest extends TestCase
         ::createFromFormat(static::$dateFormat, $endDateStr)
         ->sub(new DateInterval('P7D'))
         ->format(static::$dateFormat);
-        $expect = [ 'severity', $startDateStr, $endDateStr, 'required by' ];
+        $expect = [ 'severity', $startDateStr, $endDateStr, 'milestone' ];
 
         $this->assertSame($expect, $headings);
 
         $this->assertTrue($this->sortByArrayOrder($report, static::$severityOrder));
 
         $expected = [
-            [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
-            [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
+            [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1, 'milestone' => $milestone ],
+            [ 'fieldName' => 'Critical', 'fromDate' => 1, 'toDate' => 1, 'milestone' => $milestone ],
         ];
         $this->assertSame($expected, $report);
     }
@@ -303,8 +303,8 @@ final class ReportTest extends TestCase
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
-            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ],
-            [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1, 'required by' => $milestone ]
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 1, 'toDate' => 1, 'milestone' => $milestone ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 1, 'toDate' => 1, 'milestone' => $milestone ]
         ];
 
         $this->assertSame($expect, $report);
@@ -320,8 +320,8 @@ final class ReportTest extends TestCase
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));
 
         $expect = [
-            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1, 'required by' => $milestone ],
-            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2, 'required by' => $milestone ],
+            [ 'fieldName' => 'Mechanical', 'fromDate' => 2, 'toDate' => 1, 'milestone' => $milestone ],
+            [ 'fieldName' => 'SCADA', 'fromDate' => 0, 'toDate' => 2, 'milestone' => $milestone ],
         ];
 
         $this->assertSame($expect, $report);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -162,8 +162,7 @@ final class ReportTest extends TestCase
 
     public function testSeverityReportWithEarlierStartDateContainsExpectedData(): void
     {
-        $startDate = DateTime::createFromFormat(static::$dateFormat, '2019-07-01');
-        $startDateStr = $startDate->format(static::$dateFormat);
+        $startDateStr = '2019-07-01';
 
         $report = Report::delta('severity', $startDateStr);
         $this->assertInstanceOf(Report::class, $report);
@@ -172,7 +171,7 @@ final class ReportTest extends TestCase
 
         $headings = array_shift($reportData);
         $expected = [ 'severity', $startDateStr, date('Y-m-d')];
-        $this->assertSame($headings, $expected);
+        $this->assertSame($expected, $headings);
 
         $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
 
@@ -181,6 +180,30 @@ final class ReportTest extends TestCase
             [ 'fieldName' => 'Major', 'fromDate' => 1, 'toDate' => 1 ],
             [ 'fieldName' => 'Critical', 'fromDate' => 2, 'toDate' => 1 ],
             [ 'fieldName' => 'Blocker', 'fromDate' => 2, 'toDate' => 1 ],
+        ], $reportData);
+    }
+
+    public function testSeverityReportWithEarlierStartAndEndDatesContainsExpectedData(): void
+    {
+        $startDateStr = '2019-05-01';
+        $endDateStr = '2019-07-01';
+
+        $report = Report::delta('severity', $startDateStr, $endDateStr);
+        $this->assertInstanceOf(Report::class, $report);
+
+        $reportData = $report->getWithHeadings();
+
+        $headings = array_shift($reportData);
+        $expected = [ 'severity', $startDateStr, $endDateStr ];
+        $this->assertSame($expected, $headings);
+
+        $this->assertTrue(usort($reportData, [$this, 'sortBySeverityName']));
+
+        $this->assertSame([
+            [ 'fieldName' => 'Minor', 'fromDate' => 1, 'toDate' => 1 ],
+            [ 'fieldName' => 'Major', 'fromDate' => 2, 'toDate' => 1 ],
+            [ 'fieldName' => 'Critical', 'fromDate' => 2, 'toDate' => 2 ],
+            [ 'fieldName' => 'Blocker', 'fromDate' => 0, 'toDate' => 2 ],
         ], $reportData);
     }
 

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -221,7 +221,6 @@ final class ReportTest extends TestCase
     {
         $milestone = 4;
         $report = Report::delta('severity', null, null, $milestone);
-        fwrite(STDOUT, $report->getQuery());
 
         $reportData = $report->getWithHeadings();
 
@@ -308,7 +307,6 @@ final class ReportTest extends TestCase
     public function testDefaultSystemReportWithMilestoneReturnsExpectedData(): void
     {
         $report = Report::delta('system', null, null, 5);
-        fwrite(STDOUT, $report->getQuery());
         $report = $report->getWithHeadings();
         array_shift($report);
         $this->assertTrue($this->sortByArrayOrder($report, static::$systemOrder));


### PR DESCRIPTION
- Reworks Report class to take 4 arguments, (1) `severity` or `system`, to group open defs accordingly, (2, 3) arguments for start date and end date, (4) milestone to filter defs by `requiredBy`
  - Also fixes open defs for date range query
- Creates form, found at the bottom of dashboard, for user to get report for different
- Includes tests for new report