### PR TITLE
fix a bunch of Notice: undefined errors

### DIFF
--- a/ForgotPassword.php
+++ b/ForgotPassword.php
@@ -174,6 +174,5 @@ if ($_SESSION['badCount'] >= 3)
     mysqli_close($link); ?>
     </div>
     </div>
-    <?php include 'footer.html'; ?>
   </body>
 </html>

--- a/SecQSubmit.php
+++ b/SecQSubmit.php
@@ -56,9 +56,9 @@ mysqli_close($link);
     </HEAD>
     <BODY>
 <?php
-        include('filestart.php');
-        echo $message;
-        include 'fileend.php';
+    include('filestart.php');
+    if (!empty($message)) echo $message;
+    include 'fileend.php';
 ?>
     </BODY>
 </HTML>

--- a/addUserSubmit.php
+++ b/addUserSubmit.php
@@ -101,7 +101,7 @@ else {
     <body>
         <?php include('filestart.php');
         echo "<h1>Adding user failed</h1>";
-        echo $message;
+        if (!empty($message)) echo $message;
         include('fileend.php') ?>
     </body>
 </html>

--- a/def.php
+++ b/def.php
@@ -83,7 +83,7 @@ try {
     
     // instantiate Twig
     $loader = new Twig_Loader_Filesystem('./templates');
-    $twig = new Twig_Environment($loader, [ 'debug' => $_ENV['PHP_ENV'] === 'dev' ]);
+    $twig = new Twig_Environment($loader, [ 'debug' => getenv('PHP_ENV') === 'dev' ]);
     $twig->addExtension(new Twig_Extension_Debug());
     // $template = $twig->load();
 

--- a/defs.php
+++ b/defs.php
@@ -29,7 +29,7 @@ if(!empty($_GET)) {
 $loader = new Twig_Loader_Filesystem('./templates');
 $twig = new Twig_Environment($loader,
     [
-        'debug' => $_ENV['PHP_ENV'] === 'dev'
+        'debug' => getenv('PHP_ENV') === 'dev'
     ]
 );
 if (getenv('PHP_ENV')) {

--- a/filestart.php
+++ b/filestart.php
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title><?php echo $title ?></title>
+    <title><?php echo !empty($title) ? $title : '' ?></title>
     <link rel='icon' type='image/x-icon' href='/favicon.ico'>
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">

--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -282,7 +282,7 @@ class Deficiency
                 ) {
                     $this->props[$propsKey] = empty($numericProps[$propsKey])
                         ? trim($value)
-                        : intval($value);
+                        : $this->falsyValueForZero($value);
                 } elseif (is_numeric($key) && array_key_exists($value, $this->props)) {
                     $this->props[$value] = null;
                 }
@@ -522,7 +522,7 @@ class Deficiency
      * If no props names passed, returns all string values
      */
     public function getReadable($props = null) { // TODO: takes an optional array of props to join and return
-        // TODO: test for presence of $props in foreignKeys
+        // test for presence of $props in foreignKeys
         $foreignKeys = $props ?
             array_filter(static::$foreignKeys, function($key) use ($props) {
                 return array_search($key, $props) !== false;

--- a/newDef.php
+++ b/newDef.php
@@ -6,7 +6,7 @@ use SVBX\Deficiency;
 
 if ($_SESSION['role'] <= 10
     || (empty($_SESSION['bdPermit'])
-    && ($_POST['class'] === 'bart' || $_GET['class' === 'bart']))) {
+    && ($_POST['class'] === 'bart' || $_GET['class'] === 'bart'))) {
     error_log('Unauthorized client tried to access newdef.php from ' . $_SERVER['HTTP_ORIGIN']);
     header('This is not for you', true, 403);
     exit;
@@ -144,8 +144,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // instantiate Twig
     $loader = new Twig_Loader_Filesystem('./templates');
-    $twig = new Twig_Environment($loader, [ 'debug' => $_ENV['PHP_ENV'] === 'dev' ]);
-    if ($_ENV['PHP_ENV'] === 'dev') $twig->addExtension(new Twig_Extension_Debug());
+    $twig = new Twig_Environment($loader, [ 'debug' => getenv('PHP_ENV') === 'dev' ]);
+    if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug());
 
     $context = [
         'session' => $_SESSION,

--- a/setSQ.php
+++ b/setSQ.php
@@ -39,6 +39,5 @@
   </form>
   </div>
   </div>
-<?php include 'footer.html';?>
 </body>
 </html>

--- a/updateDef.php
+++ b/updateDef.php
@@ -11,9 +11,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // TODO: this should reject early if no ID
     // TODO: controller should take a generic `id` prop and an additional `class` prop to determine whether it's a BART Def
     $id = intval($_POST['id']);
-    $class = sprintf('SVBX\%sDeficiency', $_POST['class']);
-    $qs = '?' . ($_POST['class'] ? "class={$_POST['class']}&" : '' );
-    $updatedByField = $_POST['class'] === 'bart' ? 'userID' : 'username';
+    $class = sprintf('SVBX\%sDeficiency', !empty($_POST['class']) ? $_POST['class'] : '');
+    $qs = '?' . (!empty($_POST['class']) ? "class={$_POST['class']}&" : '' );
+    $updatedByField = (!empty($_POST['class']) && $_POST['class'] === 'bart')
+        ? 'userID' : 'username';
     try {
         $ref = new ReflectionClass($class);
         $def = $ref->newInstanceArgs([ $id, $_POST ]);
@@ -49,7 +50,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
 
-        if ($_FILES['attachment']['size']
+        if (!empty($_FILES['attachment'])
+            && $_FILES['attachment']['size']
             && $_FILES['attachment']['name']
             && $_FILES['attachment']['tmp_name']
             && $_FILES['attachment']['type'])
@@ -97,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         error_log($e);
         $_SESSION['errorMsg'] = 'Something went wrong in trying to update deficiency: ' . $e->getMessage();
         $qs = '?'
-            . ($_POST['class'] === 'bart'
+            . (!empty(($_POST['class']) && $_POST['class']) === 'bart'
                 ? 'class=bart&' : '')
             . http_build_query($def->get());
         $location = $_SERVER['PHP_SELF'];
@@ -209,7 +211,7 @@ try {
 
     // instantiate Twig
     $loader = new Twig_Loader_Filesystem('./templates');
-    $twig = new Twig_Environment($loader, [ 'debug' => $_ENV['PHP_ENV'] === 'dev' ]);
+    $twig = new Twig_Environment($loader, [ 'debug' => getenv('PHP_ENV') === 'dev' ]);
     $twig->addExtension(new Twig_Extension_Debug());
     $twig->display($templatePath, $context);
 } catch (Twig_Error $e) {


### PR DESCRIPTION
I need to clean up these trivial Notice errors to reduce the noise in the production error_log.

I don't want to turn off logging of error-level 'Notice' because notice-level errors might be valuable in debugging future bugs.