### PR TITLE
fix up some things about BART IDs on main Deficiencies

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -44,6 +44,7 @@ try {
     $view = 'deficiency';
     $headings = [
         'id' => '_id',
+        'bartDefID' => 'BART ID',
         'location' => 'Location',
         'severity' => 'Severity',
         'status' => 'Status',
@@ -97,6 +98,7 @@ try {
             if (strcasecmp($key, 'identifiedby') === 0
             || strcasecmp($key, 'specloc') === 0
             || strcasecmp($key, 'id') === 0
+            || strcasecmp($key, 'bartDefID') === 0
             || strcasecmp($key, 'description') === 0) {
                 $link->where($key, "%{$val}%", 'LIKE');
             } elseif (strcasecmp($key, 'systemAffected') === 0

--- a/api/def.php
+++ b/api/def.php
@@ -199,6 +199,7 @@ try {
     }
 
     array_unshift($defs, $headings);
+    error_log(print_r($defs, true));
 
     $csv = Writer::createFromFileObject(new SplTempFileObject());
     $csv->setNewline("\r\n");

--- a/api/def.php
+++ b/api/def.php
@@ -199,7 +199,6 @@ try {
     }
 
     array_unshift($defs, $headings);
-    error_log(print_r($defs, true));
 
     $csv = Writer::createFromFileObject(new SplTempFileObject());
     $csv->setNewline("\r\n");

--- a/def.php
+++ b/def.php
@@ -85,7 +85,6 @@ try {
     $loader = new Twig_Loader_Filesystem('./templates');
     $twig = new Twig_Environment($loader, [ 'debug' => getenv('PHP_ENV') === 'dev' ]);
     $twig->addExtension(new Twig_Extension_Debug());
-    // $template = $twig->load();
 
     $twig->display($templatePath, $context);
 } catch (Twig_Error $e) {

--- a/def.php
+++ b/def.php
@@ -86,6 +86,12 @@ try {
     $twig = new Twig_Environment($loader, [ 'debug' => getenv('PHP_ENV') === 'dev' ]);
     $twig->addExtension(new Twig_Extension_Debug());
 
+    // add custom Twig filters
+    $zerofill = new Twig_Filter('zerofill_*', function($num, $str) {
+        return $str ? str_pad($str, $num, '0', STR_PAD_LEFT) : $str;
+    });
+    $twig->addFilter($zerofill);
+    
     $twig->display($templatePath, $context);
 } catch (Twig_Error $e) {
     echo "Unable to render template";

--- a/defs.php
+++ b/defs.php
@@ -40,10 +40,11 @@ if (getenv('PHP_ENV')) {
 $filter_decode = new Twig_Filter('safe', function($str) {
     return html_entity_decode($str);
 });
-$zerofill = new Twig_Filter('zerofill', function($str, $len) {
-    return str_pid($str, $len, '0', STR_PAD_LEFT);
+$zerofill = new Twig_Filter('zerofill_*', function($num, $str) {
+    return $str ? str_pad($str, $num, '0', STR_PAD_LEFT) : $str;
 });
-$twig->addFilter($filter_decode);    
+$twig->addFilter($filter_decode);
+$twig->addFilter($zerofill);
 
 // set view-dependent variables
 $bartTableHeadings = [
@@ -58,7 +59,7 @@ $bartTableHeadings = [
 
 $projectTableHeadings = [
     'ID' => [ 'value' => 'ID', 'cellWd' => '1', 'collapse' => 'none def-table__col-id', 'href' => '/def.php?defID=' ],
-    'bartID' => [ 'value' => 'BART ID', 'cellWd' => '1', 'collapse' => 'sm' ],
+    'bartID' => [ 'value' => 'BART ID', 'filter' => 'zerofill_4', 'cellWd' => '1', 'collapse' => 'sm' ],
     'location' => [ 'value' => 'Location', 'cellWd' => '2', 'collapse' => 'sm' ],
     'severity' => [ 'value' => 'Severity', 'cellWd' => '1', 'collapse' => 'xs' ],
     'status' => [ 'value' => 'Status', 'cellWd' => '2' ],

--- a/defs.php
+++ b/defs.php
@@ -40,6 +40,9 @@ if (getenv('PHP_ENV')) {
 $filter_decode = new Twig_Filter('safe', function($str) {
     return html_entity_decode($str);
 });
+$zerofill = new Twig_Filter('zerofill', function($str, $len) {
+    return str_pid($str, $len, '0', STR_PAD_LEFT);
+});
 $twig->addFilter($filter_decode);    
 
 // set view-dependent variables

--- a/migrations/20190906001250-add-bartDefID-to-def-view.js
+++ b/migrations/20190906001250-add-bartDefID-to-def-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190906001250-add-bartDefID-to-def-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190906001250-add-bartDefID-to-def-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190906001250-add-bartDefID-to-def-view-down.sql
+++ b/migrations/sqls/20190906001250-add-bartDefID-to-def-view-down.sql
@@ -1,0 +1,24 @@
+/* add bartDefID to def view DOWN */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20190906001250-add-bartDefID-to-def-view-up.sql
+++ b/migrations/sqls/20190906001250-add-bartDefID-to-def-view-up.sql
@@ -1,0 +1,25 @@
+/* add bartDefID to def view UP */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20190906001250-add-bartDefID-to-def-view-up.sql
+++ b/migrations/sqls/20190906001250-add-bartDefID-to-def-view-up.sql
@@ -1,7 +1,7 @@
 /* add bartDefID to def view UP */
 CREATE OR REPLACE VIEW deficiency AS
     SELECT CDL.defID AS id,
-    bartDefID,
+    LPAD(bartDefID, 4, '0') as bartDefID,
     loc.locationName AS location,
     sev.severityName AS severity,
     stat.statusName AS status,

--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -212,12 +212,6 @@ class Deficiency
             'table' => 'repo',
             'fields' => ['repoID', 'repoName']
         ],
-        'bartDefID' => [
-            'table' => 'BARTDL',
-            'alias' => 'bart',
-            'fields' => [ 'ID' ],
-            'order' => [ 'ID', 'ASC' ]
-        ],
         'created_by' => [
             'table' => 'users_enc',
             'alias' => 'cb',

--- a/model/Deficiency.php
+++ b/model/Deficiency.php
@@ -87,7 +87,7 @@ class Deficiency
         'evidenceID' => 'FILTER_SANITIZE_SPECIAL_CHARS',
         'evidenceLink' => 'FILTER_SANITIZE_SPECIAL_CHARS',
         'oldID' => 'FILTER_SANITIZE_SPECIAL_CHARS',
-        'bartDefID' => 'intval',
+        'bartDefID' => 'FILTER_SANITIZE_NUMBER_INT',
         'closureComments' => 'FILTER_SANITIZE_SPECIAL_CHARS',
         'created_by' => false,
         'updated_by' => false,
@@ -309,7 +309,7 @@ class Deficiency
             $propName = !empty($this->filters[$key]) ? $key : array_search($key, $this->fields);
             $filter = $this->filters[$propName];
             if (strpos($filter, 'FILTER') === 0)
-                $acc[$key] = filter_var($props[$key], constant($filter));
+                $acc[$key] = filter_var($props[$key], constant($filter)) ?: null;
             elseif ($filter !== false) {
                 // this if condition should be temporary
                 // use only until all '0000-00-00' dates are properly set to NULL
@@ -320,7 +320,7 @@ class Deficiency
             else $acc[$key] = $props[$key];
             // trim & stripcslashes here should be temporary
             // may be removed once all tainted Defs are cleaned of '\r\n'
-            $acc[$key] = trim(stripcslashes($acc[$key]));
+            if (is_string($acc[$key])) $acc[$key] = trim(stripcslashes($acc[$key]));
             return $acc;
         }, []);
     }

--- a/templates/def.html.twig
+++ b/templates/def.html.twig
@@ -70,7 +70,7 @@
     <div class='col-md-3'><p>Old Id</p></div>
     <div class='col-md-3'>{{ page.input_like(data.oldID) }}</div>
     <div class='col-md-3'><p>BART ID</p></div>
-    <div class='col-md-3'>{{ page.input_like(data.bartDefID) }}</div>
+    <div class='col-md-3'>{{ page.input_like(data.bartDefID | zerofill_4()) }}</div>
 </div>
 {% include 'includes/closureInfo.html.twig' %}
 {% if not data.comments is empty %}

--- a/templates/defForm.html.twig
+++ b/templates/defForm.html.twig
@@ -220,9 +220,7 @@
                                 <label for='bartDefID'>BART ID</label>
                             </div>
                             <div class='col-md-6'>
-                                <select name='bartDefID' id='bartDefID' class='form-control'>
-                                    {{ form.renderOptions(options.bartDefID, data.bartDefID) }}
-                                </select>
+                                <input type="number" name="bartDefID" id="bartDefID" min="1" max="9999" value="{{ data.bartDefID | raw }}" class="form-control">
                             </div>
                         </div>
                     </div>

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -53,7 +53,7 @@
             const view = getQueryValue('view')
             const fields = view && view === 'BART'
                 ? 'id,status,date_created,description,resolution,nextStep,comment&view=BART'
-                : 'id,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
+                : 'id,bartDefID,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
             let filters = window.location.search
                 .toLowerCase()
                 .slice(1)

--- a/templates/template_fcns/tables.xml.twig
+++ b/templates/template_fcns/tables.xml.twig
@@ -100,16 +100,22 @@
                     ? headings[fieldName].href|trim
                     : headings[fieldName].href|trim ~ id|trim %}
             {% else %}{% endif %}
+
+            {% set cellVal %}
+                {% if headings[fieldName].filter | slice(0, 10) == 'zerofill_4' %}
+                    {{ cell | zerofill_4() }}
+                {% else %}
+                    {{ cell }}
+                {% endif %}
+            {% endset %}
             
             {% if not cell is iterable %}
                 {# if cell is simple scalar then check for href, classes on heading for cell #}
                 {% set cellContent %}
                     {% if not href is empty %}
                         {{ tables.anchorTag(href, id | trim) }}
-                    {% elseif cell is same as('0000-00-00') %}
-                        {{ '—' }}
-                    {% elseif not cell is empty %}
-                        {{ cell | trim | raw | nl2br }}
+                    {% elseif not cell is empty and not cell is same as('0000-00-00') %}
+                        {{ cellVal | trim | raw | nl2br }}
                     {% else %}
                         {{ '—' }}
                     {% endif %}

--- a/tests/DeficiencyTest.php
+++ b/tests/DeficiencyTest.php
@@ -187,4 +187,29 @@ final class DeficiencyTest extends TestCase
 
         $this->assertNotEquals(intval($this->newDefID), 0);
     }
+
+    public function testEmptyBartIdDoesNotInsertZero(): void
+    {
+        $this->newDefID = (new Deficiency(null, [
+            'safetyCert' => 1,
+            'systemAffected' => 1,
+            'location' => 1,
+            'specLoc' => 'test_specLoc',
+            'status' => 1,
+            'severity' => 1,
+            'dueDate' => date(static::$dateFormat),
+            'groupToResolve' => 1,
+            'requiredBy' => 1,
+            'contractID' => 1,
+            'identifiedBy' => 'ckb',
+            'defType' => 1,
+            'description' => 'test_description',
+            'bartDefID' => null,
+            'created_by' => 'test_user', // required creation info
+        ]))->insert();
+
+        $newDef = new Deficiency($this->newDefID);
+        $this->assertNotEquals($newDef->get('bartDefID'), 0);
+        $this->assertEquals($newDef->get('bartDefID'), null);
+    }
 }

--- a/tests/DeficiencyTest.php
+++ b/tests/DeficiencyTest.php
@@ -156,17 +156,6 @@ final class DeficiencyTest extends TestCase
 
     public function testCanInsertWithBartId(): void
     {
-        $this->bartDefID = (new BARTDeficiency(null, [
-            'creator' => 1,
-            'status' => 1,
-            'descriptive_title_vta' => 'test description',
-            'root_prob_vta' => 'test root problem',
-            'resolution_vta' => 'test resolution vta',
-            'priority_vta' => 1,
-            'safety_cert_vta' => 1,
-            'created_by' => 1
-        ]))->insert();
-
         $this->newDefID = (new Deficiency(false, [
             'safetyCert' => 1,
             'systemAffected' => 1,
@@ -181,7 +170,7 @@ final class DeficiencyTest extends TestCase
             'identifiedBy' => 'ckb',
             'defType' => 1,
             'description' => 'test_description',
-            'bartDefID' => $this->bartDefID,
+            'bartDefID' => 5555,
             'created_by' => 'test_user', // required creation info
         ]))->insert();
 

--- a/updateDef.php
+++ b/updateDef.php
@@ -9,7 +9,6 @@ if ($_SESSION['role'] <= 10) {
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // TODO: this should reject early if no ID
-    // TODO: controller should take a generic `id` prop and an additional `class` prop to determine whether it's a BART Def
     $id = intval($_POST['id']);
     $class = sprintf('SVBX\%sDeficiency', !empty($_POST['class']) ? $_POST['class'] : '');
     $qs = '?' . (!empty($_POST['class']) ? "class={$_POST['class']}&" : '' );


### PR DESCRIPTION
1. Make BART IDs take an arbitrary integer. No more linking to existing BART IDs in database.
2. Make BART IDs zero-fill in Defs table display
3. Add bartDefID to CSV output on Defs table page

_**ISSUE:**_ I don't have a good way to test the API endpoint because it is not OOP.