### PR TITLE
migration to allow `repo` to be null

### DIFF
--- a/migrations/20190911222642-allow-null-repo.js
+++ b/migrations/20190911222642-allow-null-repo.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190911222642-allow-null-repo-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190911222642-allow-null-repo-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190911222642-allow-null-repo-down.sql
+++ b/migrations/sqls/20190911222642-allow-null-repo-down.sql
@@ -1,0 +1,4 @@
+/* allow NULL repo DOWN */
+ALTER TABLE CDL
+    MODIFY repo
+        INT(11) NOT NULL;

--- a/migrations/sqls/20190911222642-allow-null-repo-up.sql
+++ b/migrations/sqls/20190911222642-allow-null-repo-up.sql
@@ -1,0 +1,4 @@
+/* allow NULL repo UP */
+ALTER TABLE CDL
+    MODIFY repo
+        INT(11) DEFAULT NULL;

--- a/tests/DeficiencyTest.php
+++ b/tests/DeficiencyTest.php
@@ -89,6 +89,29 @@ final class DeficiencyTest extends TestCase
         $this->assertEquals($dateCreated, $d->format(static::$dateFormat));
     }
 
+    public function testCanInsertWithNullRepo() : void
+    {
+        $this->newDefID = (new Deficiency(false, [
+            'safetyCert' => 1,
+            'systemAffected' => 1,
+            'location' => 1,
+            'specLoc' => 'test_specLoc',
+            'status' => 1,
+            'severity' => 1,
+            'dueDate' => date(static::$dateFormat),
+            'groupToResolve' => 1,
+            'requiredBy' => 1,
+            'contractID' => 1,
+            'identifiedBy' => 'ckb',
+            'defType' => 1,
+            'description' => 'test_description',
+            'created_by' => 'test_user', // required creation info
+            'repo' => null
+        ]))->insert();
+        
+        $this->assertNotEquals(intval($this->newDefID), 0);
+    }
+
     public function testInsertWithStatusClosedGetsTimestamp(): void
     {
         $this->newDefID = (new Deficiency(false, [


### PR DESCRIPTION
Currently there is a bug in prod where new defs with empty value for `repo` are being rejected.

Allow `repo` to be NULL because why not?