### PR TITLE
rm empty onsubmit= from defForm

### DIFF
--- a/templates/defForm.html.twig
+++ b/templates/defForm.html.twig
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block content %}
-    <form name="defForm" action='{{ formAction }}' method='POST' enctype='multipart/form-data' onsubmit='' class='item-margin-bottom'>
+    <form name="defForm" action='{{ formAction }}' method='POST' enctype='multipart/form-data' class='item-margin-bottom'>
         {% block formControls %}
             <input type='hidden' name='id' value='{{ data.id }}'>
             <h4 class='pad grey-bg'>Required Information</h4>

--- a/updateDef.php
+++ b/updateDef.php
@@ -8,7 +8,6 @@ if ($_SESSION['role'] <= 10) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    error_log('updateDef received POST ' . print_r($_POST, true));
     // TODO: this should reject early if no ID
     $id = intval($_POST['id']);
     $class = sprintf('SVBX\%sDeficiency', !empty($_POST['class']) ? $_POST['class'] : '');
@@ -21,9 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $def->set('updated_by', $_SESSION[$updatedByField]);
         if (empty($id)) throw new Exception('No ID found for update request');
 
-        error_log('Def #' . $def->get('id') . ' ready for update' . $def);
         $success = $def->update();
-        error_log('Def #' . $def->get('id') . ' successfully updated');
 
         // if UPDATE succesful, prepare, upload, and INSERT photo
         // TODO: make all this one transcaction handled by the Deficiency object
@@ -124,7 +121,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // TODO: this should fail early if no ID or if invalid class
 // TODO: this should show an error to the user for missing ID or invalid class
 try {
-    error_log('updateDef received GET ' . print_r($_GET, true));
     if (empty($_GET['id'])) throw new Exception('No id received for update request form');
     if (empty($_GET)) throw new Exception('No data received for update request form');
     $class = 'SVBX\%sDeficiency';


### PR DESCRIPTION
Form element on defForm template, used by updateDef and newDef, has `onsubmit=""`. This is preempting the form's `action` attribute in a very few cases. (Why not all cases? The world may never know.)

Remove that empty `onsubmit` attribute to fix the problem.