### PR TITLE
fix a couple breaking bugs on api/def

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -107,27 +107,23 @@ try {
             && is_array($val))
             {
                 // fetch systemIDs because they are not in the view
+                $lowerKey = strtolower($key);
                 $tableLookup = [
-                    'systemAffected' => 'system',
-                    'groupToResolve' => 'system',
+                    'systemaffected' => 'system',
+                    'grouptoresolve' => 'system',
                     'status' => 'status'
                 ];
-                $table = $tableLookup[$key];
+                $table = $tableLookup[$lowerKey];
+
                 $link2 = new MySqliDB(DB_CREDENTIALS);
                 $lookup = $link2->get($table, null, [ "{$table}ID id", "{$table}Name name" ]);
                 $link2->disconnect();
-                // $lookup = array_reduce($lookup, function ($dict, $row) use ($table) {
-                //     $dict[$row["id"]] = $row["name"];
-                //     return $dict;
-                // }, []);
+
                 $lookup = array_combine(array_column($lookup, 'id'), array_column($lookup, 'name'));
-                //  [ $lookup[array_shift($val)] ];
-                // foreach ($val as $extraVal) {
-                //     $arrayVals[] = $system[$extraVal];
-                // }
                 $namedVals = array_map(function ($num) use ($lookup) {
                     return $lookup[$num];
                 }, $val);
+
                 $link->where($key, $namedVals, 'IN');
             } elseif (strcasecmp($key, 'requiredBy') === 0) {
                 $table = 'requiredBy'; // mind the capitalization

--- a/defs.php
+++ b/defs.php
@@ -378,7 +378,10 @@ try {
 
     // instantiate Twig
     $twig = new Twig_Environment(new Twig_Loader_Filesystem('./templates'),
-        [ 'debug' => getenv('PHP_ENV') === 'dev' ]
+        [
+            'debug' => getenv('PHP_ENV') === 'dev',
+            'autoescape' => false
+        ]
     );
     if (getenv('PHP_ENV') === 'dev') $twig->addExtension(new Twig_Extension_Debug());
 
@@ -392,6 +395,7 @@ try {
     $twig->addFilter($filter_decode);
     $twig->addFilter($zerofill);
 
+    error_log(print_r($context['data'], true));
     $twig->display('defs.html.twig', $context);
 } catch (Twig_Error $e) {
     error_log($e->getTemplateLine() . ' ' . $e->getRawMessage());

--- a/defs.php
+++ b/defs.php
@@ -395,7 +395,6 @@ try {
     $twig->addFilter($filter_decode);
     $twig->addFilter($zerofill);
 
-    error_log(print_r($context['data'], true));
     $twig->display('defs.html.twig', $context);
 } catch (Twig_Error $e) {
     error_log($e->getTemplateLine() . ' ' . $e->getRawMessage());

--- a/migrations/20190918231942-add-safetcert-def-view.js
+++ b/migrations/20190918231942-add-safetcert-def-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190918231942-add-safetcert-def-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190918231942-add-safetcert-def-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190918231942-add-safetcert-def-view-down.sql
+++ b/migrations/sqls/20190918231942-add-safetcert-def-view-down.sql
@@ -1,0 +1,26 @@
+/* add safetyCert to deficiency VIEW DOWN */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID
+    

--- a/migrations/sqls/20190918231942-add-safetcert-def-view-up.sql
+++ b/migrations/sqls/20190918231942-add-safetcert-def-view-up.sql
@@ -1,0 +1,26 @@
+/* add safetyCert to deficiency VIEW UP */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment,
+    CDL.safetyCert safetyCert
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/templates/template_fcns/tables.xml.twig
+++ b/templates/template_fcns/tables.xml.twig
@@ -105,7 +105,7 @@
                 {% if headings[fieldName].filter | slice(0, 10) == 'zerofill_4' %}
                     {{ cell | zerofill_4() }}
                 {% else %}
-                    {{ cell | safe }}
+                    {{ cell }}
                 {% endif %}
             {% endset %}
             
@@ -115,7 +115,7 @@
                     {% if not href is empty %}
                         {{ tables.anchorTag(href, id | trim) }}
                     {% elseif not cell is empty and not cell is same as('0000-00-00') %}
-                        {{ cellVal | trim | raw | nl2br }}
+                        {{- cellVal | trim | nl2br | safe -}}
                     {% else %}
                         {{ '—' }}
                     {% endif %}


### PR DESCRIPTION
1. Lowercase the keys of 'systemAffected' and 'groupToResolve' so that I can reliably match them in the lookup for the purpose of getting their corresponding table name
2. Add safetyCert to the deficiency view so that can WHERE clause on it
3. BONUS: Change how values are un-escaped on the defs table because Twig is fussy and weird about un-escaping stuff. *This may be be an ongoing challenge.