### PR TITLE
add closure info to csv export

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -64,13 +64,6 @@ try {
         'comment' => 'Comments'
     ];
 
-    // order fields according to headings order
-    $fields = array_values(array_intersect(
-        array_replace(
-            array_change_key_case($headings), array_change_key_case(array_combine(array_flip($fields), $fields)
-        )), $fields
-    ));
-
     if (!empty($get['view'])) {
         if (strtolower($get['view']) === 'bart') {
             $view = 'bart_def';
@@ -104,6 +97,13 @@ try {
         $link->where('id', $to, '<=');
         unset($get['range']);
     }
+
+    // order fields according to headings order
+    $fields = array_values(array_intersect(
+        array_replace(
+            array_change_key_case($headings), array_change_key_case(array_combine(array_flip($fields), $fields)
+        )), $fields
+    ));
 
     // filter defs with remaining GET params
     if (!empty($get)) {

--- a/api/def.php
+++ b/api/def.php
@@ -28,7 +28,6 @@ if (strcasecmp($_SERVER['REQUEST_METHOD'], 'GET')) {
 }
 
 try {
-    // check Session vars against DB
     $link = new MySqliDB(DB_CREDENTIALS);
 
     if (empty($_GET['fields'])) {
@@ -56,8 +55,22 @@ try {
         'dueDate' => 'Due Date',
         'defType' => 'Type',
         'actionOwner' => 'Action Owner',
+        // closure infos
+        'evidenceID' => 'Document ID',
+        'evidenceType' => 'Evidence Type',
+        'repo' => 'Evidence Repository',
+        'evidenceLink' => 'Document Link',
+        'closureComments' => 'Closure Comments',
         'comment' => 'Comments'
     ];
+
+    // order fields according to headings order
+    $fields = array_values(array_intersect(
+        array_replace(
+            array_change_key_case($headings), array_change_key_case(array_combine(array_flip($fields), $fields)
+        )), $fields
+    ));
+
     if (!empty($get['view'])) {
         if (strtolower($get['view']) === 'bart') {
             $view = 'bart_def';

--- a/js/get_csv.js
+++ b/js/get_csv.js
@@ -1,0 +1,46 @@
+const getCsv = ev => {
+    ev.preventDefault()
+    const view = getQueryValue('view')
+    const fields = 'fields='
+        + (view && view === 'BART'
+            ? 'id,status,date_created,description,resolution,nextStep,comment&view=BART'
+            : 'id,bartDefID,location,severity,status,systemaffected,grouptoresolve'
+            + ',description,specloc,requiredby,duedate,deftype,actionowner,evidenceid'
+            + ',evidencetype,repo,evidencelink,closurecomments,comment')
+
+    let filters = window.location.search
+        .toLowerCase()
+        .slice(1)
+        .replace('view=bart', '')
+
+    filters = filters.startsWith('&') ? filters : `&${filters}`
+
+    const querystring = '?' + fields + filters
+    const url = '/api/def.php' + querystring
+    fetch(url, {
+        credentials: 'same-origin',
+        headers: { 'Accept': 'text/csv' }
+    }).then(res => {
+        if (!res.ok) {
+            console.error(`${res.status}: ${res.statusText}`)
+            throw res.text()
+        }
+        return res.text()
+    }).then(text => {
+        const d = new Date()
+        const timestamp = d.getFullYear()
+            + '' + (d.getMonth() + 1)
+            + '' + d.getDate()
+            + '' + (d.getHours() < 10 ? '0' + d.getHours() : d.getHours())
+            + '' + (d.getMinutes() < 10 ? '0' + d.getMinutes() : d.getMinutes())
+            + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
+        download(text, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
+    }).catch(err => {
+        if (typeof err.then === 'function') {
+            err.then(text => {
+                console.error(text)
+            })
+        }
+        else console.error(err)
+    })
+}

--- a/migrations/20190919181846-add-closure-info-def-view.js
+++ b/migrations/20190919181846-add-closure-info-def-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190919181846-add-closure-info-def-view-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190919181846-add-closure-info-def-view-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190919181846-add-closure-info-def-view-down.sql
+++ b/migrations/sqls/20190919181846-add-closure-info-def-view-down.sql
@@ -1,0 +1,26 @@
+/* add closure info to def view DOWN */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    com.cdlCommText AS comment,
+    CDL.safetyCert safetyCert
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20190919181846-add-closure-info-def-view-up.sql
+++ b/migrations/sqls/20190919181846-add-closure-info-def-view-up.sql
@@ -1,0 +1,33 @@
+/* add closure info to def view UP */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    CDL.safetyCert safetyCert,
+    repo.repoName repo,
+    evi.eviTypeName evidenceType,
+    CDL.evidenceID evidenceID,
+    CDL.evidenceLink evidenceLink,
+    CDL.closureComments closureComments,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN repo ON CDL.repo = repo.repoID
+    LEFT JOIN evidenceType evi ON CDL.evidenceType = evi.eviTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -38,6 +38,7 @@
     <script src="js/dedupe_selection.js"></script>
     <script src="https://d3js.org/d3.v5.js"></script>
     <script src="js/pie_chart.js"></script>
+    <script src="js/get_csv.js"></script>
     <script>
         document.forms.filterForm.addEventListener('submit', {{submitScript.function | default("unnameEmptyFormControls") | raw}})
         document.getElementById('reset-btn').addEventListener('click', ev => {
@@ -49,51 +50,7 @@
                 dedupeSelection(ev.target, collection, {{sortOptions | json_encode() | raw}})
             })
         })
-        document.getElementById('getCsvBtn').addEventListener('click', event => {
-            const view = getQueryValue('view')
-            const fields = view && view === 'BART'
-                ? 'id,status,date_created,description,resolution,nextStep,comment&view=BART'
-                : 'id,bartDefID,location,severity,status,systemaffected,grouptoresolve,description,specloc,requiredby,duedate,deftype,actionowner,comment'
-
-            let filters = window.location.search
-                .toLowerCase()
-                .slice(1)
-                .replace('view=bart', '')
-            filters = filters.split('&')
-            if (filters[filters.indexOf('defid')])
-                filters[filters.indexOf('defid')] = filters[filters.indexOf('defid')].replace('defid', 'id')
-            filters = filters.join('&')
-            filters = filters.startsWith('&') ? filters : `&${filters}`
-
-            const querystring = '?fields=' + fields + filters
-            const url = '/api/def.php' + querystring
-            fetch(url, {
-                credentials: 'same-origin',
-                headers: { 'Accept': 'text/csv' }
-            }).then(res => {
-                if (!res.ok) {
-                    console.error(`${res.status}: ${res.statusText}`)
-                    throw res.text()
-                }
-                return res.text()
-            }).then(text => {
-                const d = new Date()
-                const timestamp = d.getFullYear()
-                    + '' + (d.getMonth() + 1)
-                    + '' + d.getDate()
-                    + '' + (d.getHours() < 10 ? '0' + d.getHours() : d.getHours())
-                    + '' + (d.getMinutes() < 10 ? '0' + d.getMinutes() : d.getMinutes())
-                    + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
-                download(text, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
-            }).catch(err => {
-                if (typeof err.then === 'function') {
-                    err.then(text => {
-                        console.error(text)
-                    })
-                }
-                else console.error(err)
-            })
-        })
+        document.getElementById('getCsvBtn').addEventListener('click', getCsv)
         function getQueryValue(key) {
             if (!window.location.search) return false
             const qs = qsToObj()


### PR DESCRIPTION
The title p much says it all.

Add `repo`, `evidenceID`, `evidenceType`, `evidenceLink`, and `closureComments` to CSV export, `api/def.php`.

Adds migration to add aforementioned five fields to `deficiency` view in db.