### PR TITLE
fix: stop lowercasing def filters. That way table names match properly

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -37,6 +37,7 @@ try {
     }
 
     $get = $_GET;
+    error_log("GET params look like\n" . print_r($get, true));
     $fields = explode(',', $get['fields']);
     unset($get['fields']);
 

--- a/api/def.php
+++ b/api/def.php
@@ -37,7 +37,6 @@ try {
     }
 
     $get = $_GET;
-    error_log("GET params look like\n" . print_r($get, true));
     $fields = explode(',', $get['fields']);
     unset($get['fields']);
 
@@ -111,7 +110,6 @@ try {
     // filter defs with remaining GET params
     if (!empty($get)) {
         foreach ($get as $key => $val) {
-            error_log('table key is ' . $key . ', and val is ' . $val);
             // for these free text fields (and ID) use LIKE comparison
             if (strcasecmp($key, 'identifiedby') === 0
             || strcasecmp($key, 'specloc') === 0
@@ -180,7 +178,6 @@ try {
             // don't get safetyCert lookup coz safetyCert table is for something else entirely
             elseif (($view === 'deficiency' && strcasecmp($key, 'safetyCert') !== 0)
             || ($view === 'bart_def' && strcasecmp($key, 'status') === 0)) {
-                error_log(__LINE__ . '> did we hit the case we thought we\'d hit?');
                 $table = $key;
                 $id = "{$table}ID";
                 $name = "{$table}Name";

--- a/api/def.php
+++ b/api/def.php
@@ -110,6 +110,7 @@ try {
     // filter defs with remaining GET params
     if (!empty($get)) {
         foreach ($get as $key => $val) {
+            error_log('table key is ' . $key . ', and val is ' . $val);
             // for these free text fields (and ID) use LIKE comparison
             if (strcasecmp($key, 'identifiedby') === 0
             || strcasecmp($key, 'specloc') === 0
@@ -178,6 +179,7 @@ try {
             // don't get safetyCert lookup coz safetyCert table is for something else entirely
             elseif (($view === 'deficiency' && strcasecmp($key, 'safetyCert') !== 0)
             || ($view === 'bart_def' && strcasecmp($key, 'status') === 0)) {
+                error_log(__LINE__ . '> did we hit the case we thought we\'d hit?');
                 $table = $key;
                 $id = "{$table}ID";
                 $name = "{$table}Name";

--- a/js/get_csv.1576293141364.js
+++ b/js/get_csv.1576293141364.js
@@ -9,7 +9,6 @@ const getCsv = ev => {
     fields = 'fields=' + fields
 
     let filters = window.location.search
-        .toLowerCase()
         .slice(1)
         .replace('view=bart', '')
 
@@ -22,8 +21,7 @@ const getCsv = ev => {
         headers: { 'Accept': 'text/csv' }
     }).then(res => {
         if (!res.ok) {
-            console.error(`${res.status}: ${res.statusText}`)
-            throw res.text()
+            throw Error(`${res.status}: ${res.statusText} @ target ${url}`)
         }
         return res.text()
     }).then(text => {
@@ -36,11 +34,6 @@ const getCsv = ev => {
             + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
         download(text, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
     }).catch(err => {
-        if (typeof err.then === 'function') {
-            err.then(text => {
-                console.error(text)
-            })
-        }
-        else console.error(err)
+        console.error(err)
     })
 }

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -38,7 +38,7 @@
     <script src="js/dedupe_selection.js"></script>
     <script src="https://d3js.org/d3.v5.js"></script>
     <script src="js/pie_chart.1569442076436.js"></script>
-    <script type="text/javascript" src="js/get_csv.1576288770505.js"></script>
+    <script type="text/javascript" src="js/get_csv.1576293141364.js"></script>
     <script>
         document.forms.filterForm.addEventListener('submit', {{submitScript.function | default("unnameEmptyFormControls") | raw}})
         document.getElementById('reset-btn').addEventListener('click', ev => {


### PR DESCRIPTION
The JS script that was fetching the CSV from the API was doing toLowerCase() on the query string before sending it. This was causing the `def` API endpoint to not match the table `defType`. By complete (un)happy accident, it was still finding all the other tables that hit that case if the if/else chain because I guess their names weren't camelled. Hope it works now 🤞