### PR TITLE
Fix: workaround bug in downloadjs to encode non-ascii chars properly

### DIFF
--- a/js/get_csv.1578088580417.js
+++ b/js/get_csv.1578088580417.js
@@ -20,7 +20,7 @@ const getCsv = ev => {
         credentials: 'same-origin',
         headers: { 'Accept': 'text/csv' }
     }).then(res => {
-        if (!res.ok) throw Error(res.statusText)
+        if (!res.ok) throw Error(`${res.status}: ${res.statusText} @ ${res.url}`)
         return res.blob()
     }).then(blob => {
         const d = new Date()

--- a/js/get_csv.1578088580417.js
+++ b/js/get_csv.1578088580417.js
@@ -20,11 +20,9 @@ const getCsv = ev => {
         credentials: 'same-origin',
         headers: { 'Accept': 'text/csv' }
     }).then(res => {
-        if (!res.ok) {
-            throw Error(`${res.status}: ${res.statusText} @ target ${url}`)
-        }
-        return res.text()
-    }).then(text => {
+        if (!res.ok) throw Error(res.statusText)
+        return res.blob()
+    }).then(blob => {
         const d = new Date()
         const timestamp = d.getFullYear()
             + '' + (d.getMonth() + 1)
@@ -32,7 +30,7 @@ const getCsv = ev => {
             + '' + (d.getHours() < 10 ? '0' + d.getHours() : d.getHours())
             + '' + (d.getMinutes() < 10 ? '0' + d.getMinutes() : d.getMinutes())
             + '' + (d.getSeconds() < 10 ? '0' + d.getSeconds() : d.getSeconds())
-        download(text, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
+        download(blob, `${view || ''}defs_summary_${timestamp}.csv`, 'text/csv')
     }).catch(err => {
         console.error(err)
     })

--- a/templates/defs.html.twig
+++ b/templates/defs.html.twig
@@ -38,7 +38,7 @@
     <script src="js/dedupe_selection.js"></script>
     <script src="https://d3js.org/d3.v5.js"></script>
     <script src="js/pie_chart.1569442076436.js"></script>
-    <script type="text/javascript" src="js/get_csv.1576293141364.js"></script>
+    <script type="text/javascript" src="js/get_csv.1578088580417.js"></script>
     <script>
         document.forms.filterForm.addEventListener('submit', {{submitScript.function | default("unnameEmptyFormControls") | raw}})
         document.getElementById('reset-btn').addEventListener('click', ev => {


### PR DESCRIPTION
Downloadjs has a [known, and old, bug](https://github.com/rndme/download/issues/56) where non-ascii characters get mangled. We are encountering problems with this in Deficiencies text that contains bulleted lists.

Per one of the suggestions in the issue thread, this PR changes get_csv.js to return the response body as a blob instead as text. Then downloadjs handles the characters correctly.