### PR TITLE
Order comments in CSV dump by date_created, descending

### DIFF
--- a/api/def.php
+++ b/api/def.php
@@ -197,10 +197,14 @@ try {
     }
 
     $link->orderBy('id', 'ASC');
+    if ($includeComments = (array_search('comment', $fields) !== false)) {
+        $link->orderBy('comment_date', 'DESC');
+    }
+
     $defs = $link->get($view, null, $fields);
 
     // if comments included, combine defs and put comments in extra cols
-    if (array_search('comment', $fields) !== false) {
+    if ($includeComments) {
         $next = null;
         $comments = [];
         $output = [];

--- a/migrations/20200121212847-def-view-add-comment-date.js
+++ b/migrations/20200121212847-def-view-add-comment-date.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200121212847-def-view-add-comment-date-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20200121212847-def-view-add-comment-date-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20200121212847-def-view-add-comment-date-down.sql
+++ b/migrations/sqls/20200121212847-def-view-add-comment-date-down.sql
@@ -1,0 +1,34 @@
+/* def view add comment date DOWN */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    CDL.safetyCert safetyCert,
+    repo.repoName repo,
+    evi.eviTypeName evidenceType,
+    CDL.evidenceID evidenceID,
+    CDL.evidenceLink evidenceLink,
+    CDL.FinalGroup FinalGroup,
+    CDL.closureComments closureComments,
+    com.cdlCommText AS comment
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN repo ON CDL.repo = repo.repoID
+    LEFT JOIN evidenceType evi ON CDL.evidenceType = evi.eviTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID

--- a/migrations/sqls/20200121212847-def-view-add-comment-date-up.sql
+++ b/migrations/sqls/20200121212847-def-view-add-comment-date-up.sql
@@ -1,0 +1,35 @@
+/* def view add comment_date UP */
+CREATE OR REPLACE VIEW deficiency AS
+    SELECT CDL.defID AS id,
+    LPAD(bartDefID, 4, '0') as bartDefID,
+    loc.locationName AS location,
+    sev.severityName AS severity,
+    stat.statusName AS status,
+    sys.systemName AS systemAffected,
+    grp.systemName AS groupToResolve,
+    CDL.description AS description,
+    CDL.specLoc AS specLoc,
+    req.requiredBy AS requiredBy,
+    DATE_FORMAT(CDL.dueDate, "%d %b %Y") AS dueDate,
+    type.defTypeName AS defType,
+    CDL.actionOwner AS actionOwner,
+    CDL.safetyCert safetyCert,
+    repo.repoName repo,
+    evi.eviTypeName evidenceType,
+    CDL.evidenceID evidenceID,
+    CDL.evidenceLink evidenceLink,
+    CDL.FinalGroup FinalGroup,
+    CDL.closureComments closureComments,
+    com.cdlCommText AS comment,
+    com.date_created AS comment_date
+    FROM CDL
+    LEFT JOIN location loc ON CDL.location = loc.locationID
+    LEFT JOIN severity sev ON CDL.severity = sev.severityID
+    LEFT JOIN status stat ON CDL.status = stat.statusID
+    LEFT JOIN system sys ON CDL.systemAffected = sys.systemID
+    LEFT JOIN system grp ON CDL.groupToResolve = grp.systemID
+    LEFT JOIN requiredBy req ON CDL.requiredBy = req.reqByID
+    LEFT JOIN defType type ON CDL.defType = type.defTypeID
+    LEFT JOIN repo ON CDL.repo = repo.repoID
+    LEFT JOIN evidenceType evi ON CDL.evidenceType = evi.eviTypeID
+    LEFT JOIN cdlComments com ON CDL.defID = com.defID


### PR DESCRIPTION
Currently comments get attached to their respective deficiencies in seemingly arbitrary order.

This PR adds a comment_date field to the deficiency view used by /api/def.php, and then sorts on that field, after sorting on id. This way, comments show in the CSV dump in the same order they show on the browser view.